### PR TITLE
scripts: Re-add tags for hypervisor config script

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -153,6 +153,8 @@ show_array()
 		tags=$(echo "$entry"|cut -s -d: -f1)
 		elem=$(echo "$entry"|cut -s -d: -f2-)
 
+		[ -z "$elem" ] && die "no option for entry '$entry'"
+
 		check_tags "$tags" "$entry"
 
 		if [ "$action" = "dump" ]

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -175,6 +175,17 @@ show_array()
 # Entry point
 main()
 {
+	local qemu_version_file="VERSION"
+	[ -f ${qemu_version_file} ] || die "QEMU version file '$qemu_version_file' not found"
+
+	local qemu_version_major=$(cut -d. -f1 "${qemu_version_file}")
+	local qemu_version_minor=$(cut -d. -f2 "${qemu_version_file}")
+
+	[ -n "${qemu_version_major}" ] \
+		|| die "cannot determine qemu major version from file $qemu_version_file"
+	[ -n "${qemu_version_minor}" ] \
+		|| die "cannot determine qemu minor version from file $qemu_version_file"
+
 	arch=$(arch)
 
 	# Array of configure options.

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -290,7 +290,7 @@ main()
 
 	# SECURITY: Don't build a static binary (lowers security)
 	# needed if qemu version is less than 2.7
-	if [ ${qemu_version_major} -eq 2 ] && [ ${qemu_version_minor} -lt 7 ]; then
+	if [ "${qemu_version_major}" -eq 2 ] && [ "${qemu_version_minor}" -lt 7 ]; then
 		qemu_options+=(security:--disable-static)
 	fi
 
@@ -333,7 +333,7 @@ main()
 
 	# Always strip binaries
 	# needed if qemu version is less than 2.7
-	if [ ${qemu_version_major} -eq 2 ] && [ ${qemu_version_minor} -lt 7 ]; then
+	if [ "${qemu_version_major}" -eq 2 ] && [ "${qemu_version_minor}" -lt 7 ]; then
 		qemu_options+=(size:--enable-strip)
 	fi
 

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -96,6 +96,7 @@ check_tag()
 
 	value="${recognised_tags[$tag]}"
 
+	# each tag MUST have a description
 	[ -n "$value" ] && return
 
 	die "invalid tag '$tag' found for entry '$entry'"

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -93,6 +93,7 @@ check_tag()
 	local entry="$2"
 
 	[ -z "$tag" ] && die "no tag for entry '$entry'"
+	[ -z "$entry" ] && die "no entry for tag '$tag'"
 
 	value="${recognised_tags[$tag]}"
 
@@ -108,6 +109,7 @@ check_tags()
 	local entry="$2"
 
 	[ -z "$tags" ] && die "entry '$entry' doesn't have any tags"
+	[ -z "$entry" ] && die "no entry for tags '$tags'"
 
 	tags=$(echo "$tags"|tr ',' '\n')
 
@@ -146,6 +148,8 @@ show_array()
 
 	for entry in "${_array[@]}"
 	do
+		[ -z "$entry" ] && die "found empty entry"
+
 		tags=$(echo "$entry"|cut -s -d: -f1)
 		elem=$(echo "$entry"|cut -s -d: -f2-)
 

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -282,7 +282,7 @@ main()
 	# SECURITY: Don't build a static binary (lowers security)
 	# needed if qemu version is less than 2.7
 	if [ ${qemu_version_major} -eq 2 ] && [ ${qemu_version_minor} -lt 7 ]; then
-		qemu_options+=(--disable-static)
+		qemu_options+=(security:--disable-static)
 	fi
 
 	# Not required as "-uuid ..." is always passed to the qemu binary
@@ -325,7 +325,7 @@ main()
 	# Always strip binaries
 	# needed if qemu version is less than 2.7
 	if [ ${qemu_version_major} -eq 2 ] && [ ${qemu_version_minor} -lt 7 ]; then
-		qemu_options+=(--enable-strip)
+		qemu_options+=(size:--enable-strip)
 	fi
 
 	# Support Ceph RADOS Block Device (RBD)

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -92,6 +92,8 @@ check_tag()
 	local tag="$1"
 	local entry="$2"
 
+	[ -z "$tag" ] && die "no tag for entry '$entry'"
+
 	value="${recognised_tags[$tag]}"
 
 	[ -n "$value" ] && return


### PR DESCRIPTION
PR #12 inadvertently removed the required tags for two of the qemu
config options.

Partially fixes #13.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>