### PR TITLE
ci: Add initial CI scripts

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script will execute packaing tests suite
+# TODO: Add steps neded to build packages
+true

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo  "Setup script for packaging"

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO: Add teardown steps as need
+true


### PR DESCRIPTION
Add base scripts to setup, run, and teardown tests
for ci.

Fixes: #21

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>