### PR TITLE
ci: Add initial CI scripts

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script will execute packaging tests suite
+# TODO: Add steps needed to build packages
+true

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo  "Setup script for packaging"

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script should run any static analysis check
+# It is called by the CI setup
+true

--- a/.ci/teardown.sh
+++ b/.ci/teardown.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO: Add teardown steps as need
+true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
+MK_DIR :=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+.PHONY: test test-release-tools
+
+test: test-release-tools
+
+test-release-tools:
+	@$(MK_DIR)/release/tag_repos_test.sh

--- a/release/tag_repos.sh
+++ b/release/tag_repos.sh
@@ -84,8 +84,9 @@ tag_repos() {
 
 	info "Creating tag ${kata_version} in all repos"
 	for repo in "${repos[@]}"; do
-		git clone --quiet "git@github.com:${OWNER}/${repo}.git"
+		git clone --quiet "https://github.com/${OWNER}/${repo}.git"
 		pushd "${repo}"
+		git remote set-url --push origin "git@github.com:${OWNER}/${repo}.git"
 		git fetch origin --tags
 		if git rev-parse -q --verify "refs/tags/${kata_version}"; then
 			info "$repo already has tag "

--- a/release/tag_repos_test.sh
+++ b/release/tag_repos_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Check tag_repos.sh show help"
+./release/tag_repos.sh  | grep Usage
+
+echo "Check tag_repos.sh -h option"
+./release/tag_repos.sh  -h | grep Usage
+
+echo "Check tag_repos.sh status"
+./release/tag_repos.sh status | grep runtime
+
+echo "Check tag_repos.sh create tags but not push"
+./release/tag_repos.sh tag | grep "tags not pushed"


### PR DESCRIPTION
Add base scripts to setup, run, and teardown tests
for ci.

Fixes: #21

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>