### PR TITLE
pkg: kernel: Add kernel config version to pkg version.

### DIFF
--- a/kernel/kata-linux-container.dsc-template
+++ b/kernel/kata-linux-container.dsc-template
@@ -1,6 +1,6 @@
 Format: 3.0 (quilt)
 Source: kata-linux-container
-Version: @VERSION@-@RELEASE@
+Version: @VERSION@.@CONFIG_VERSION@-@RELEASE@
 Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>

--- a/kernel/kata-linux-container.spec-template
+++ b/kernel/kata-linux-container.spec-template
@@ -7,7 +7,7 @@
 %define bzimage_arch x86
 
 Name:           kata-linux-container
-Version:        @VERSION@
+Version:        @VERSION@.@CONFIG_VERSION@
 Release:        @RELEASE@.<B_CNT>
 License:        GPL-2.0
 Summary:        The Linux kernel optimized for running inside a container

--- a/kernel/update.sh
+++ b/kernel/update.sh
@@ -19,6 +19,7 @@ SCRIPT_DIR=$(dirname $0)
 
 PKG_NAME="kata-linux-container"
 VERSION=$kernel_version
+KATA_CONFIG_VERSION=$(cat "${SCRIPT_DIR}/kata_config_version")
 
 KR_SERIES="$(echo $VERSION | cut -d "." -f 1).x"
 KR_LTS=$(echo $VERSION | cut -d "." -f 1,2)
@@ -45,7 +46,8 @@ kernel_sha256=$(curl -L -s -f ${KR_SHA} | awk '/linux-'${VERSION}'.tar.xz/ {prin
 cp "configs/x86_kata_kvm_${KR_LTS}.x" config
 
 replace_list=(
-"VERSION=$VERSION"
+"VERSION=${VERSION}"
+"CONFIG_VERSION=${KATA_CONFIG_VERSION}"
 "RELEASE=$RELEASE"
 "KERNEL_SHA256=$kernel_sha256"
 )
@@ -53,6 +55,6 @@ replace_list=(
 verify
 echo "Verify succeed."
 get_git_info
-changelog_update $VERSION
+changelog_update "${VERSION}-${KATA_CONFIG_VERSION}"
 generate_files "$SCRIPT_DIR" "${replace_list[@]}"
 build_pkg "${PROJECT_REPO}"

--- a/runtime/update.sh
+++ b/runtime/update.sh
@@ -50,7 +50,8 @@ SHIM_REQUIRED_VERSION=$(pkg_version "${kata_shim_version}" "${SHIM_RELEASE}" "${
 info "shim ${SHIM_REQUIRED_VERSION}"
 
 KERNEL_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/linux-container")
-KERNEL_REQUIRED_VERSION=$(pkg_version "${kernel_version}" "${KERNEL_RELEASE}")
+KERNEL_CONFIG_VERSION=$(cat "${SCRIPT_DIR}/../kernel/kata_config_version")
+KERNEL_REQUIRED_VERSION=$(pkg_version "${kernel_version}.${KERNEL_CONFIG_VERSION}" "${KERNEL_RELEASE}")
 info "kata-linux-container ${KERNEL_REQUIRED_VERSION}"
 
 KSM_THROTTLER_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/ksm-throttler")


### PR DESCRIPTION
Add the version of config and patches we are using in a package.

Kernel version before:

4.14.22-128

Now:

4.14.22.1-128

Fixes: #45

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>