### PR TITLE
tag_repos: Make sure osbuilder is updated.

### DIFF
--- a/release/tag_repos.sh
+++ b/release/tag_repos.sh
@@ -61,11 +61,12 @@ info() {
 }
 
 repos=(
-	"runtime"
-	"proxy"
-	"shim"
 	"agent"
 	"ksm-throttler"
+	"osbuilder"
+	"proxy"
+	"runtime"
+	"shim"
 )
 
 check_versions() {
@@ -127,10 +128,9 @@ status)
 	;;
 tag)
 	check_versions
-	# Tag versions that does not have VESIONS file
-	# But we want to know the version compatrible with a kata release.
+	# Tag versions that does not have VERSIONS file
+	# But we want to know the version compatible with a kata release.
 	repos+=("tests")
-	repos+=("osbuilder")
 	tag_repos
 	if [ "${PUSH}" == "true" ]; then
 		push_tags


### PR DESCRIPTION
Make sure the osbuilder VERSION file is updated before tag

Also, sort repos alphabetically.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>