### PR TITLE
image build: Improve image generation

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -23,7 +23,6 @@ install_yq() {
 	# https://github.com/mikefarah/yq/releases/tag/<VERSION-HERE>
 	yq_version=$(basename "${yq_latest_url}")
 
-
 	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_linux_${goarch}"
 	curl -o "${yq_path}" -L "${yq_url}"
 	chmod +x "${yq_path}"
@@ -53,3 +52,12 @@ die() {
 info() {
 		echo >&2 "INFO: $*"
 }
+
+get_repo_hash(){
+	local repo_dir=${1:-}
+	[ -d "${repo_dir}" ] || die "${repo_dir} is not a directory"
+	pushd "${repo_dir}" >> /dev/null
+	git rev-parse --verify HEAD
+	popd >> /dev/null
+}
+


### PR DESCRIPTION
This PR reworks the existing script to create images for a release.

It creates a tarball with more explicit names. 
- The tarball includes the architecture that was used to build the tarball.
 - Useful to publish the image in agent repository.
- Added usage help message.
- Build master by default but allow to define a tag for agent and osbuilder version.