### PR TITLE
ci: refine qemu-options for arm64

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -16,6 +16,22 @@
 
 script_name=${0##*/}
 
+arch=$(arch)
+
+# Array of configure options.
+#
+# Each element is comprised of two parts in the form:
+#
+#   tags:option
+#
+# Where,
+#
+# - 'tags' is a comma-separated list of values which denote why
+#   the option is being specified.
+#
+# - 'option' is the hypervisor configuration option.
+typeset -a qemu_options
+
 typeset -A recognised_tags
 
 recognised_tags=(
@@ -183,26 +199,220 @@ show_array()
 	[ "$one_line" = yes ] && echo
 }
 
+generate_qemu_options()
+{
+	#---------------------------------------------------------------------
+	# Disabled options
+
+	# bluetooth support not required
+	qemu_options+=(size:--disable-bluez)
+
+	# braille support not required
+	qemu_options+=(size:--disable-brlapi)
+
+	# Don't build documentation
+	qemu_options+=(minimal:--disable-docs)
+
+	# Disable GUI (graphics)
+	qemu_options+=(size:--disable-curses)
+	qemu_options+=(size:--disable-gtk)
+	qemu_options+=(size:--disable-opengl)
+	qemu_options+=(size:--disable-sdl)
+	qemu_options+=(size:--disable-spice)
+	qemu_options+=(size:--disable-vte)
+
+	# Disable graphical network access
+	qemu_options+=(size:--disable-vnc)
+	qemu_options+=(size:--disable-vnc-jpeg)
+	qemu_options+=(size:--disable-vnc-png)
+	qemu_options+=(size:--disable-vnc-sasl)
+
+	# Disable unused filesystem support
+	[ "$arch" == x86_64 ] && qemu_options+=(size:--disable-fdt)
+	qemu_options+=(size:--disable-glusterfs)
+	qemu_options+=(size:--disable-libiscsi)
+	qemu_options+=(size:--disable-libnfs)
+	qemu_options+=(size:--disable-libssh2)
+
+	# Disable unused compression support
+	qemu_options+=(size:--disable-bzip2)
+	qemu_options+=(size:--disable-lzo)
+	qemu_options+=(size:--disable-snappy)
+
+	# Disable unused security options
+	qemu_options+=(security:--disable-seccomp)
+	qemu_options+=(security:--disable-tpm)
+
+	# Disable userspace network access ("-net user")
+	qemu_options+=(size:--disable-slirp)
+
+	# Disable USB
+	qemu_options+=(size:--disable-libusb)
+	qemu_options+=(size:--disable-usb-redir)
+
+	# Disable TCG support
+	case "$arch" in
+		aarch64) ;;
+		x86_64)  qemu_options+=(size:--disable-tcg);;
+		ppc64le) qemu_options+=(size:--disable-tcg);;
+        esac
+
+	# SECURITY: Don't build a static binary (lowers security)
+	# needed if qemu version is less than 2.7
+	if [ "${qemu_version_major}" -eq 2 ] && [ "${qemu_version_minor}" -lt 7 ]; then
+		qemu_options+=(security:--disable-static)
+	fi
+
+	if [ "${static}" == "true" ]; then
+		qemu_options+=(misc:--static)
+	fi
+
+	# Not required as "-uuid ..." is always passed to the qemu binary
+	qemu_options+=(size:--disable-uuid)
+
+	# Disable debug
+	case "$arch" in
+		aarch64) ;;
+		x86_64)
+			qemu_options+=(size:--disable-debug-tcg)
+			qemu_options+=(size:--disable-tcg-interpreter)
+			;;
+                ppc64le)
+			qemu_options+=(size:--disable-debug-tcg)
+			qemu_options+=(size:--disable-tcg-interpreter)
+			;;
+        esac
+	qemu_options+=(size:--disable-qom-cast-debug)
+	qemu_options+=(size:--disable-tcmalloc)
+
+	# Disallow network downloads
+	qemu_options+=(security:--disable-curl)
+
+	# Disable Remote Direct Memory Access (Live Migration)
+	# https://wiki.qemu.org/index.php/Features/RDMALiveMigration
+	qemu_options+=(size:--disable-rdma)
+
+	# Don't build the qemu-io, qemu-nbd and qemu-image tools
+	qemu_options+=(size:--disable-tools)
+
+	# Disable XEN driver
+	case "$arch" in
+		aarch64) ;;
+		x86_64)  qemu_options+=(size:--disable-xen);;
+		ppc64le) qemu_options+=(size:--disable-xen);;
+        esac
+
+	# FIXME: why is this disabled?
+	# (for reference, it's explicitly enabled in Ubuntu 17.10 and
+	# implicitly enabled in Fedora 27).
+	qemu_options+=(size:--disable-linux-aio)
+
+	#---------------------------------------------------------------------
+	# Enabled options
+
+	# Enable kernel Virtual Machine support.
+	# This is the default, but be explicit to avoid any future surprises
+	qemu_options+=(speed:--enable-kvm)
+
+	# Required for fast network access
+	qemu_options+=(speed:--enable-vhost-net)
+
+	# Always strip binaries
+	# needed if qemu version is less than 2.7
+	if [ "${qemu_version_major}" -eq 2 ] && [ "${qemu_version_minor}" -lt 7 ]; then
+		qemu_options+=(size:--enable-strip)
+	fi
+
+	# Support Ceph RADOS Block Device (RBD)
+	[ -z "${static}" ] && qemu_options+=(functionality:--enable-rbd)
+
+	# In "passthrough" security mode
+	# (-fsdev "...,security_model=passthrough,..."), qemu uses a helper
+	# application called virtfs-proxy-helper(1) to make certain 9p
+	# operations safer.
+	qemu_options+=(functionality:--enable-virtfs)
+	qemu_options+=(functionality:--enable-attr)
+	qemu_options+=(functionality:--enable-cap-ng)
+
+	#---------------------------------------------------------------------
+	# Other options
+
+	# 64-bit only
+	qemu_options+=(arch:"--target-list=${arch}-softmmu")
+
+	_qemu_cflags=""
+
+	# compile with high level of optimisation
+	_qemu_cflags+=" -O3"
+
+	# Improve code quality by assuming identical semantics for interposed
+	# synmbols.
+	# Only enable if gcc is 5.3 or newer
+	if [ "${gcc_version_major}" -ge 5 ] && [ "${gcc_version_minor}" -ge 3 ]; then
+		_qemu_cflags+=" -fno-semantic-interposition"
+	fi
+
+	# Performance optimisation
+	_qemu_cflags+=" -falign-functions=32"
+
+	# SECURITY: make the compiler check for common security issues
+	# (such as argument and buffer overflows checks).
+	_qemu_cflags+=" -D_FORTIFY_SOURCE=2"
+
+	# SECURITY: Create binary as a Position Independant Executable,
+	# and take advantage of ASLR, making ROP attacks much harder to perform.
+	# (https://wiki.debian.org/Hardening)
+	case "$arch" in
+		aarch64) _qemu_cflags+=" -fPIC";;
+		x86_64)  _qemu_cflags+=" -fPIE";;
+		ppc64le) _qemu_cflags+=" -fPIE";;
+	esac
+
+	# Set compile options
+	qemu_options+=(functionality,security,speed,size:"--extra-cflags=\"${_qemu_cflags}\"")
+
+	unset _qemu_cflags
+
+	_qemu_ldflags=""
+
+	# SECURITY: Link binary as a Position Independant Executable,
+	# and take advantage of ASLR, making ROP attacks much harder to perform.
+	# (https://wiki.debian.org/Hardening)
+	case "$arch" in
+		aarch64) ;;
+		x86_64)  [ -z "${static}" ] && _qemu_ldflags+=" -pie";;
+		ppc64le) [ -z "${static}" ] && _qemu_ldflags+=" -pie";;
+	esac
+
+	# SECURITY: Disallow executing code on the stack.
+	_qemu_ldflags+=" -z noexecstack"
+
+	# SECURITY: Make the linker set some program sections to read-only
+	# before the program is run to stop certain attacks.
+	_qemu_ldflags+=" -z relro"
+
+	# SECURITY: Make the linker resolve all symbols immediately on program
+	# load.
+	_qemu_ldflags+=" -z now"
+
+	qemu_options+=(security:"--extra-ldflags=\"${_qemu_ldflags}\"")
+
+	unset _qemu_ldflags
+
+	# Where to install qemu libraries
+	qemu_options+=(arch:--libdir=/usr/lib64/${hypervisor})
+
+	# Where to install qemu helper binaries
+	qemu_options+=(misc:--libexecdir=/usr/libexec/${hypervisor})
+
+	# Where to install data files
+	qemu_options+=(misc:--datadir=/usr/share/${hypervisor})
+
+}
+
 # Entry point
 main()
 {
-
-	arch=$(arch)
-
-	# Array of configure options.
-	#
-	# Each element is comprised of two parts in the form:
-	#
-	#   tags:option
-	#
-	# Where,
-	#
-	# - 'tags' is a comma-separated list of values which denote why
-	#   the option is being specified.
-	#
-	# - 'option' is the hypervisor configuration option.
-	typeset -a qemu_options
-
 	action=""
 
 	while getopts "dhms" opt
@@ -250,187 +460,8 @@ main()
 	[ -n "${gcc_version_minor}" ] \
 		|| die "cannot determine gcc minor version, please ensure it is installed"
 
-	#---------------------------------------------------------------------
-	# Disabled options
-
-	# bluetooth support not required
-	qemu_options+=(size:--disable-bluez)
-
-	# braille support not required
-	qemu_options+=(size:--disable-brlapi)
-
-	# Don't build documentation
-	qemu_options+=(minimal:--disable-docs)
-
-	# Disable GUI (graphics)
-	qemu_options+=(size:--disable-curses)
-	qemu_options+=(size:--disable-gtk)
-	qemu_options+=(size:--disable-opengl)
-	qemu_options+=(size:--disable-sdl)
-	qemu_options+=(size:--disable-spice)
-	qemu_options+=(size:--disable-vte)
-
-	# Disable graphical network access
-	qemu_options+=(size:--disable-vnc)
-	qemu_options+=(size:--disable-vnc-jpeg)
-	qemu_options+=(size:--disable-vnc-png)
-	qemu_options+=(size:--disable-vnc-sasl)
-
-	# Disable unused filesystem support
-	qemu_options+=(size:--disable-fdt)
-	qemu_options+=(size:--disable-glusterfs)
-	qemu_options+=(size:--disable-libiscsi)
-	qemu_options+=(size:--disable-libnfs)
-	qemu_options+=(size:--disable-libssh2)
-
-	# Disable unused compression support
-	qemu_options+=(size:--disable-bzip2)
-	qemu_options+=(size:--disable-lzo)
-	qemu_options+=(size:--disable-snappy)
-
-	# Disable unused security options
-	qemu_options+=(security:--disable-seccomp)
-	qemu_options+=(security:--disable-tpm)
-
-	# Disable userspace network access ("-net user")
-	qemu_options+=(size:--disable-slirp)
-
-	# Disable USB
-	qemu_options+=(size:--disable-libusb)
-	qemu_options+=(size:--disable-usb-redir)
-
-	# Disable TCG support
-	qemu_options+=(size:--disable-tcg)
-
-	# SECURITY: Don't build a static binary (lowers security)
-	# needed if qemu version is less than 2.7
-	if [ "${qemu_version_major}" -eq 2 ] && [ "${qemu_version_minor}" -lt 7 ]; then
-		qemu_options+=(security:--disable-static)
-	fi
-
-	if [ "${static}" == "true" ]; then
-		qemu_options+=(misc:--static)
-	fi
-
-	# Not required as "-uuid ..." is always passed to the qemu binary
-	qemu_options+=(size:--disable-uuid)
-
-	# Disable debug
-	qemu_options+=(size:--disable-debug-tcg)
-	qemu_options+=(size:--disable-qom-cast-debug)
-	qemu_options+=(size:--disable-tcg-interpreter)
-	qemu_options+=(size:--disable-tcmalloc)
-
-	# Disallow network downloads
-	qemu_options+=(security:--disable-curl)
-
-	# Disable Remote Direct Memory Access (Live Migration)
-	# https://wiki.qemu.org/index.php/Features/RDMALiveMigration
-	qemu_options+=(size:--disable-rdma)
-
-	# Don't build the qemu-io, qemu-nbd and qemu-image tools
-	qemu_options+=(size:--disable-tools)
-
-	# Disable XEN driver
-	qemu_options+=(size:--disable-xen)
-
-	# FIXME: why is this disabled?
-	# (for reference, it's explicitly enabled in Ubuntu 17.10 and
-	# implicitly enabled in Fedora 27).
-	qemu_options+=(size:--disable-linux-aio)
-
-	#---------------------------------------------------------------------
-	# Enabled options
-
-	# Enable kernel Virtual Machine support.
-	# This is the default, but be explicit to avoid any future surprises
-	qemu_options+=(speed:--enable-kvm)
-
-	# Required for fast network access
-	qemu_options+=(speed:--enable-vhost-net)
-
-	# Always strip binaries
-	# needed if qemu version is less than 2.7
-	if [ "${qemu_version_major}" -eq 2 ] && [ "${qemu_version_minor}" -lt 7 ]; then
-		qemu_options+=(size:--enable-strip)
-	fi
-
-	# Support Ceph RADOS Block Device (RBD)
-	[ -z "${static}" ] && qemu_options+=(functionality:--enable-rbd)
-
-	# In "passthrough" security mode
-	# (-fsdev "...,security_model=passthrough,..."), qemu uses a helper
-	# application called virtfs-proxy-helper(1) to make certain 9p
-	# operations safer.
-	qemu_options+=(functionality:--enable-virtfs)
-	qemu_options+=(functionality:--enable-attr)
-	qemu_options+=(functionality:--enable-cap-ng)
-
-	#---------------------------------------------------------------------
-	# Other options
-
-	# 64-bit only
-	[ "$arch" = x86_64 ] && qemu_options+=(arch:"--target-list=${arch}-softmmu")
-
-	_qemu_cflags=""
-
-	# compile with high level of optimisation
-	_qemu_cflags+=" -O3"
-
-	# Improve code quality by assuming identical semantics for interposed
-	# synmbols.
-	# Only enable if gcc is 5.3 or newer
-	if [ "${gcc_version_major}" -ge 5 ] && [ "${gcc_version_minor}" -ge 3 ]; then
-		_qemu_cflags+=" -fno-semantic-interposition"
-	fi
-
-	# Performance optimisation
-	_qemu_cflags+=" -falign-functions=32"
-
-	# SECURITY: make the compiler check for common security issues
-	# (such as argument and buffer overflows checks).
-	_qemu_cflags+=" -D_FORTIFY_SOURCE=2"
-
-	# SECURITY: Create binary as a Position Independant Executable,
-	# and take advantage of ASLR, making ROP attacks much harder to perform.
-	# (https://wiki.debian.org/Hardening)
-	_qemu_cflags+=" -fPIE"
-
-	# Set compile options
-	qemu_options+=(functionality,security,speed,size:"--extra-cflags=\"${_qemu_cflags}\"")
-
-	unset _qemu_cflags
-
-	_qemu_ldflags=""
-
-	# SECURITY: Link binary as a Position Independant Executable,
-	# and take advantage of ASLR, making ROP attacks much harder to perform.
-	# (https://wiki.debian.org/Hardening)
-	[ -z "${static}" ] && _qemu_ldflags+=" -pie"
-
-	# SECURITY: Disallow executing code on the stack.
-	_qemu_ldflags+=" -z noexecstack"
-
-	# SECURITY: Make the linker set some program sections to read-only
-	# before the program is run to stop certain attacks.
-	_qemu_ldflags+=" -z relro"
-
-	# SECURITY: Make the linker resolve all symbols immediately on program
-	# load.
-	_qemu_ldflags+=" -z now"
-
-	qemu_options+=(security:"--extra-ldflags=\"${_qemu_ldflags}\"")
-
-	unset _qemu_ldflags
-
-	# Where to install qemu libraries
-	[ "$arch" = x86_64 ] && qemu_options+=(arch:--libdir=/usr/lib64/${hypervisor})
-
-	# Where to install qemu helper binaries
-	qemu_options+=(misc:--libexecdir=/usr/libexec/${hypervisor})
-
-	# Where to install data files
-	qemu_options+=(misc:--datadir=/usr/share/${hypervisor})
+	# Generate qemu options
+	generate_qemu_options
 
 	show_array  "$action" "${qemu_options[@]}"
 


### PR DESCRIPTION
a few qemu options generated by configure-hypervisor.sh weren't suitable for arm64, leading compilation err. lib-configure-hypervisor-aarch64.sh will create specific qemu options for arm64.

Fixes: #92

Signed-off-by: Penny Zheng <penny.zheng@arm.com>
Signed-off-by: Wei Chen <Wei.Chen@arm.com>