### PR TITLE
kata-deploy: update to use katadocker container image

### DIFF
--- a/kata-deploy/kata-cleanup.yaml
+++ b/kata-deploy/kata-cleanup.yaml
@@ -18,7 +18,7 @@ spec:
           kata-containers.io/kata-runtime: cleanup
       containers:
       - name: kube-kata-cleanup
-        image: egernst/kata-deploy
+        image: katadocker/kata-deploy
         imagePullPolicy: Always
         command: [ "sh", "-c" ]
         args:

--- a/kata-deploy/kata-deploy.yaml
+++ b/kata-deploy/kata-deploy.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kata-label-node
       containers:
       - name: kubelet-runtime-labeler-pod
-        image: egernst/kata-deploy
+        image: katadocker/kata-deploy
         imagePullPolicy: Always
         command: [ "sh", "-c" ]
         args:
@@ -56,7 +56,7 @@ spec:
           kata-containers.io/container-runtime: cri-o
       containers:
       - name: kube-kata
-        image: egernst/kata-deploy
+        image: katadocker/kata-deploy
         imagePullPolicy: Always
         lifecycle:
           preStop:
@@ -127,7 +127,7 @@ spec:
           kata-containers.io/container-runtime: containerd
       containers:
       - name: kube-kata
-        image: egernst/kata-deploy
+        image: katadocker/kata-deploy
         imagePullPolicy: Always
         lifecycle:
           preStop:


### PR DESCRIPTION
Now that initial files for kata-deploy have merged, we
have an initial image on dockerhub.  s/egernst/katadocker

Fixes: #100

Signed-off-by: Eric Ernst <eric.ernst@intel.com>