### PR TITLE
build_image.sh: OPTIND prevent unwanted word-splitting

### DIFF
--- a/obs-packaging/kata-containers-image/build_image.sh
+++ b/obs-packaging/kata-containers-image/build_image.sh
@@ -105,7 +105,7 @@ main(){
 	# Agent version
 	[ -n "${agent_version}" ] || agent_version="${kata_version}"
 
-	shift $(( "$OPTIND" - 1 ))
+	shift "$(( $OPTIND - 1 ))"
 	git clone "$osbuilder_url" "${tmp_dir}/osbuilder"
 	pushd "${tmp_dir}/osbuilder"
 	git checkout "${kata_osbuilder_version}"


### PR DESCRIPTION
shift $((OPTIND-1)) can be unsafe.To prevent unwanted
word-splitting all parameter expansions should be
double-quoted. Use the safe form for the command:
shift "$((OPTIND-1))"

Fixes: #109

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com