### PR TITLE
tag_repos.sh: fix typo

### DIFF
--- a/release/tag_repos.sh
+++ b/release/tag_repos.sh
@@ -124,7 +124,7 @@ create_github_release(){
 	[  -n "${tag}" ] || die "No repository directory"
 	if ! "${hub_bin}" release | grep "${tag}"; then
 		info "Creating Github release"
-		"${hub_bin }" -C "${repo_dir}" release create -m "${PROJECT} ${tag}" "${tag}"
+		"${hub_bin}" -C "${repo_dir}" release create -m "${PROJECT} ${tag}" "${tag}"
 	else
 		info "Github release already created"
 	fi


### PR DESCRIPTION
Fix variable name that breaks the script when creating releases.

Fixes: #121

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>