### PR TITLE
snapcraft.yaml: Use the correct powerpc kernel config name

### DIFF
--- a/snap/snapcraft.yaml.in
+++ b/snap/snapcraft.yaml.in
@@ -138,7 +138,7 @@ parts:
         ;;
 
         "ppc64le")
-          config=ppc64le_kata_kvm_4.14.x
+          config=powerpc_kata_kvm_4.14.x
         ;;
 
         "aarch64")


### PR DESCRIPTION
Kernel building fails as part of "make snap" as
the kernel config file is renamed from ppc64le_kata_kvm_4.14.x
to powerpc_kata_kvm_4.14.x

Fixes:  #127

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com