### PR TITLE
snap-build: Fix a typo in README

### DIFF
--- a/snap-build/README.md
+++ b/snap-build/README.md
@@ -1,10 +1,6 @@
 # Cross-build snap images
 
-Build Kata Containers snap images for all supported architectures using virtual machines.
-
-## Usage
-
-Run following command to build the snap images for all supported images.
+Build Kata Containers snap images for all supported architectures using virtual machines with the following command.
 
 ```
 ./xbuild.sh -a all


### PR DESCRIPTION
The #usage part of README talks about
cross building snap images for all "supported
architectures" not "supported images". 

Fixes: #131

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com