### PR TITLE
Kata deploy 1.2 dockerfile

### DIFF
--- a/kata-deploy/Dockerfile
+++ b/kata-deploy/Dockerfile
@@ -1,13 +1,15 @@
 FROM centos/systemd
-ARG KATA_VER=1.1.0
+ARG KATA_VER=1.2.0
+ARG ARCH=x86_64
 ARG KATA_URL=https://github.com/kata-containers/runtime/releases/download/${KATA_VER}
+ARG KATA_FILE=kata-static-${KATA_VER}-${ARCH}.tar.xz
 ARG KUBECTL_VER=v1.10.2
 
 RUN \
-curl -sOL ${KATA_URL}/kata-release-binaries.tar.xz && \
+curl -sOL ${KATA_URL}/${KATA_FILE} && \
 mkdir -p /opt/kata-artifacts && \
-tar xvf kata-release-binaries.tar.xz -C /opt/kata-artifacts && \
-rm kata-release-binaries.tar.xz
+tar xvf ${KATA_FILE} -C /opt/kata-artifacts/ && \
+rm ${KATA_FILE}
 
 RUN \
 curl -s -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VER}/bin/linux/amd64/kubectl && \

--- a/kata-deploy/kata-cleanup.yaml
+++ b/kata-deploy/kata-cleanup.yaml
@@ -18,7 +18,7 @@ spec:
           kata-containers.io/kata-runtime: cleanup
       containers:
       - name: kube-kata-cleanup
-        image: katadocker/kata-deploy
+        image: katadocker/kata-deploy:1.1.0
         imagePullPolicy: Always
         command: [ "sh", "-c" ]
         args:

--- a/kata-deploy/kata-deploy.yaml
+++ b/kata-deploy/kata-deploy.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kata-label-node
       containers:
       - name: kubelet-runtime-labeler-pod
-        image: katadocker/kata-deploy
+        image: katadocker/kata-deploy:1.1.0
         imagePullPolicy: Always
         command: [ "sh", "-c" ]
         args:
@@ -56,7 +56,7 @@ spec:
           kata-containers.io/container-runtime: cri-o
       containers:
       - name: kube-kata
-        image: katadocker/kata-deploy
+        image: katadocker/kata-deploy:1.1.0
         imagePullPolicy: Always
         lifecycle:
           preStop:
@@ -127,7 +127,7 @@ spec:
           kata-containers.io/container-runtime: containerd
       containers:
       - name: kube-kata
-        image: katadocker/kata-deploy
+        image: katadocker/kata-deploy:1.1.0
         imagePullPolicy: Always
         lifecycle:
           preStop:


### PR DESCRIPTION
update dockerfile to 1.2.0

Update yaml to use explicit versions, since 1.2.0 is introducing changes in how the tarball is formatted.