### PR TITLE
Kata deploy 1.2 update

### DIFF
--- a/kata-deploy/kata-cleanup.yaml
+++ b/kata-deploy/kata-cleanup.yaml
@@ -18,7 +18,7 @@ spec:
           kata-containers.io/kata-runtime: cleanup
       containers:
       - name: kube-kata-cleanup
-        image: katadocker/kata-deploy:1.1.0
+        image: katadocker/kata-deploy
         imagePullPolicy: Always
         command: [ "sh", "-c" ]
         args:

--- a/kata-deploy/kata-deploy.yaml
+++ b/kata-deploy/kata-deploy.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kata-label-node
       containers:
       - name: kubelet-runtime-labeler-pod
-        image: katadocker/kata-deploy:1.1.0
+        image: katadocker/kata-deploy
         imagePullPolicy: Always
         command: [ "sh", "-c" ]
         args:
@@ -56,7 +56,7 @@ spec:
           kata-containers.io/container-runtime: cri-o
       containers:
       - name: kube-kata
-        image: katadocker/kata-deploy:1.1.0
+        image: katadocker/kata-deploy
         imagePullPolicy: Always
         lifecycle:
           preStop:
@@ -121,7 +121,7 @@ spec:
           kata-containers.io/container-runtime: containerd
       containers:
       - name: kube-kata
-        image: katadocker/kata-deploy:1.1.0
+        image: katadocker/kata-deploy
         imagePullPolicy: Always
         lifecycle:
           preStop:

--- a/kata-deploy/kata-deploy.yaml
+++ b/kata-deploy/kata-deploy.yaml
@@ -77,8 +77,6 @@ spec:
         volumeMounts:
         - name: crio-conf
           mountPath: /etc/crio/
-        - name: kata-conf
-          mountPath: /usr/share/defaults/kata-containers/
         - name: kata-artifacts
           mountPath: /opt/kata/
         - name: dbus
@@ -89,10 +87,6 @@ spec:
         - name: crio-conf
           hostPath:
             path: /etc/crio/
-        - name: kata-conf
-          hostPath:
-            path: /usr/share/defaults/kata-containers/
-            type: DirectoryOrCreate
         - name: kata-artifacts
           hostPath:
             path: /opt/kata/
@@ -148,8 +142,6 @@ spec:
         volumeMounts:
         - name: containerd-conf
           mountPath: /etc/containerd/
-        - name: kata-conf
-          mountPath: /usr/share/defaults/kata-containers/
         - name: kata-artifacts
           mountPath: /opt/kata/
         - name: dbus
@@ -160,10 +152,6 @@ spec:
         - name: containerd-conf
           hostPath:
             path: /etc/containerd/
-            type: DirectoryOrCreate
-        - name: kata-conf
-          hostPath:
-            path: /usr/share/defaults/kata-containers/
             type: DirectoryOrCreate
         - name: kata-artifacts
           hostPath:

--- a/kata-deploy/scripts/install-kata-containerd.sh
+++ b/kata-deploy/scripts/install-kata-containerd.sh
@@ -1,16 +1,8 @@
 #!/bin/sh
 
 echo "copying kata artifacts onto host"
-cp -R /opt/kata-artifacts/bin /opt/kata/
-mkdir /opt/kata/share
-mv /opt/kata/bin/qemu /opt/kata/share/
+cp -R /opt/kata-artifacts/opt/kata/* /opt/kata/
 chmod +x /opt/kata/bin/*
-cp /opt/kata-artifacts/configuration.toml /usr/share/defaults/kata-containers/configuration.toml
-
-# Update Kata configuration for /opt/kata path usage
-sed -i 's!/usr.*kata-containers/!/opt/kata/bin/!' /usr/share/defaults/kata-containers/configuration.toml
-sed -i 's!/usr/bin/!/opt/kata/bin/!' /usr/share/defaults/kata-containers/configuration.toml
-sed -i 's!qemu-lite!qemu!' /usr/share/defaults/kata-containers/configuration.toml
 
 # Configure containerd to use Kata:
 echo "create containerd configuration for Kata"

--- a/kata-deploy/scripts/install-kata-crio.sh
+++ b/kata-deploy/scripts/install-kata-crio.sh
@@ -1,17 +1,10 @@
 #!/bin/sh
 
 echo "copying kata artifacts onto host"
-cp -R /opt/kata-artifacts/bin /opt/kata/
-mkdir /opt/kata/share
-mv /opt/kata/bin/qemu /opt/kata/share/
+cp -R /opt/kata-artifacts/opt/kata/* /opt/kata/
 chmod +x /opt/kata/bin/*
-cp /opt/kata-artifacts/configuration.toml /usr/share/defaults/kata-containers/configuration.toml
 
-# Update Kata configuration for /opt/kata path usage
-sed -i 's!/usr.*kata-containers/!/opt/kata/bin/!' /usr/share/defaults/kata-containers/configuration.toml
-sed -i 's!/usr/bin/!/opt/kata/bin/!' /usr/share/defaults/kata-containers/configuration.toml
-sed -i 's!qemu-lite!qemu!' /usr/share/defaults/kata-containers/configuration.toml
-
+# Configure crio to use Kata:
 echo "Set Kata containers as default runtime in CRI-O for untrusted workloads"
 cp /etc/crio/crio.conf /etc/crio/crio.conf.bak
 sed -i '/runtime_untrusted_workload = /c\runtime_untrusted_workload = "/opt/kata/bin/kata-runtime"' /etc/crio/crio.conf

--- a/kata-deploy/scripts/remove-kata-containerd.sh
+++ b/kata-deploy/scripts/remove-kata-containerd.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 echo "delete kata artifacts"
 rm -rf /opt/kata
-rm -rf /usr/share/defaults/kata-containers
 rm -f /etc/containerd/config.toml
 
 if [ -f /etc/containerd/config.toml.bak ]; then

--- a/kata-deploy/scripts/remove-kata-crio.sh
+++ b/kata-deploy/scripts/remove-kata-crio.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 echo "deleting kata artifacts"
 rm -rf /opt/kata/
-rm -rf /usr/share/defaults/kata-containers
 mv /etc/crio/crio.conf.bak /etc/crio/crio.conf


### PR DESCRIPTION
automated and improved tarball has slightly different format.  Update kata-deploy to make use of the new dockerfile (which uses this tarball).