### PR TITLE
Dockerfile: Install pcre-tools later to avoid dependency issue

### DIFF
--- a/obs-packaging/Dockerfile
+++ b/obs-packaging/Dockerfile
@@ -5,11 +5,11 @@ ARG SUSE_VERSION=${SUSE_VERSION:-42.3}
 ARG GO_ARCH=${GO_ARCH:-amd64}
 
 # Get OBS client, plugins and dependencies
-RUN zypper -v -n install osc-plugin-install vim curl bsdtar git sudo pcre-tools
+RUN zypper -v -n install osc-plugin-install vim curl bsdtar git sudo
 RUN curl -OkL https://download.opensuse.org/repositories/openSUSE:Tools/openSUSE_${SUSE_VERSION}/openSUSE:Tools.repo
 RUN zypper -n addrepo openSUSE:Tools.repo
 RUN zypper --gpg-auto-import-keys refresh
-RUN zypper -n install build \
+RUN zypper -v -n install build \
     obs-service-tar_scm \
     obs-service-verify_file \
     obs-service-obs_scm \
@@ -21,7 +21,7 @@ RUN curl -OL https://dl.google.com/go/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 
 # Local build dependencies
-RUN zypper -n install make gcc yum xz
+RUN zypper -v -n install make gcc yum xz pcre-tools
 
 # Add go compiler to the PATH
 ENV PATH /usr/local/go/bin:$PATH


### PR DESCRIPTION
When pcre-tools is installed before build/obs-service-tar_scm
then "build-mkbaselibs-20180629-289.1.noarch.rpm" is installed
as a dependency but OBS repo does not have that rpm. So install
"pcre-tools" at the end and Dockerfile builds fine on ppc64le.
Also, make zypper install verbose by adding "-v"

Fixes:  #139

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com