### PR TITLE
obs-packaging: Build and run Dockerfile based on GOARCH

### DIFF
--- a/obs-packaging/build_from_docker.sh
+++ b/obs-packaging/build_from_docker.sh
@@ -34,6 +34,7 @@ docker_run() {
 		-v "${HOME}/.ssh":/root/.ssh \
 		-v "${HOME}/.gitconfig":/root/.gitconfig \
 		-v /etc/profile:/etc/profile \
+		--env GO_ARCH="${GO_ARCH}" \
 		--env http_proxy="${http_proxy}" \
 		--env https_proxy="${https_proxy}" \
 		--env no_proxy="${no_proxy}" \
@@ -71,6 +72,7 @@ main() {
 	sudo docker build \
 		--build-arg http_proxy="${http_proxy}" \
 		--build-arg https_proxy="${https_proxy}" \
+		--build-arg GO_ARCH="${GO_ARCH}" \
 		-t $obs_image "${script_dir}"
 
 	#Create/update OBS repository for branch


### PR DESCRIPTION
Currently, since GOARCH is not set inside
a Dockerfile, it by default always pick's up amd64.
Pass GOARCH as build-args to fix it.

Fixes #148

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com