### PR TITLE
obs-packaging: scripts: make osc checkout verbose

### DIFF
--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -312,7 +312,7 @@ function get_obs_pkg_release() {
 	pkg=$(basename "${obs_pkg_name}")
 	repo_dir=$(mktemp -d -u -t "${pkg}.XXXXXXXXXXX")
 
-	out=$(osc -q co "${obs_pkg_name}" -o "${repo_dir}") || die "failed to checkout:$out"
+	out=$(osc -v co "${obs_pkg_name}" -o "${repo_dir}") || die "failed to checkout:$out"
 
 	spec_file=$(find "${repo_dir}" -maxdepth 1 -type f -name '*.spec' | head -1)
 	# Find in specfile in Release: XX field.


### PR DESCRIPTION
osc checkout fails silently. Make osc co
verbose as it is helpful for debugging. 

Fixes: #150

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com