### PR TITLE
obs-packaging: Skip packaging qemu-lite for non-amd64 arch

### DIFF
--- a/obs-packaging/build_all.sh
+++ b/obs-packaging/build_all.sh
@@ -65,6 +65,10 @@ eom
 
 	pushd "${script_dir}"
 	for p in "${projects[@]}"; do
+		if [[ "$GO_ARCH" != "amd64" && "$p" == "qemu-lite" ]]; then
+			echo "Skipping packaging qemu-lite as its only for amd64 arch"
+			continue
+		fi
 		pushd "$p" >>/dev/null
 		update_cmd="./update.sh"
 		if [ -n "${PUSH}" ]; then


### PR DESCRIPTION
qemu-lite is required to be packaged only
for amd64 arch. Skip it for all other
architectures.

Fixes: #152

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com