### PR TITLE
obs-packaging: set BUILD_ARCH, DEB_ARCH arch specific

### DIFF
--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -13,7 +13,7 @@ OBS_SUBPROJECT="${OBS_SUBPROJECT:-alpha}"
 
 # BUILD OPTIONS
 BUILD_DISTROS=${BUILD_DISTROS:-Fedora_27 xUbuntu_16.04 CentOS_7}
-BUILD_ARCH=${BUILD_ARCH:-}x86_64
+BUILD_ARCH="$(uname -m)"
 
 COMMIT=false
 BRANCH=false
@@ -24,7 +24,7 @@ VERBOSE=false
 # Used for debian.control files
 # Architecture: The architecture specifies which type of hardware this
 # package was compiled for.
-DEB_ARCH="${DEB_ARCH:-amd64}"
+DEB_ARCH="$(go env GOARCH)"
 
 if command -v go; then
 	export GO_ARCH=$(go env GOARCH)


### PR DESCRIPTION
pkglib.sh uses BUILD_ARCH and DEB_ARCH which are
by default not set and hence take the value of
x86_64 and amd64 respectively. Make this
architecture specific.

Fixes: #154

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com