### PR TITLE
release: dont check osbuilder VERSION file.

### DIFF
--- a/release/tag_repos.sh
+++ b/release/tag_repos.sh
@@ -66,7 +66,6 @@ info() {
 repos=(
 	"agent"
 	"ksm-throttler"
-	"osbuilder"
 	"proxy"
 	"runtime"
 	"shim"
@@ -156,6 +155,7 @@ tag)
 	# But we want to know the version compatible with a kata release.
 	repos+=("tests")
 	repos+=("packaging")
+	repos+=("osbuilder")
 	tag_repos
 	if [ "${PUSH}" == "true" ]; then
 		push_tags


### PR DESCRIPTION
The osbuilder version file wont be the same if
we tag a stable branch. But we still want to tag
the HEAD of osbuilder to do reproducible builds of
a Kata branch.

Fixes: #158