### PR TITLE
image: Make sure agent sha is  correct.

### DIFF
--- a/obs-packaging/gen_versions_txt.sh
+++ b/obs-packaging/gen_versions_txt.sh
@@ -15,11 +15,6 @@ project="kata-containers"
 
 source "${script_dir}/../scripts/lib.sh"
 
-get_kata_hash_from_tag() {
-	repo=$1
-	git ls-remote --tags "https://github.com/${project}/${repo}.git" | grep "refs/tags/${kata_version}^{}" | awk '{print $1}'
-}
-
 gen_version_file() {
 	local branch="$1"
 	[ -n "${branch}" ] || exit 1

--- a/obs-packaging/kata-containers-image/build_image.sh
+++ b/obs-packaging/kata-containers-image/build_image.sh
@@ -16,9 +16,15 @@ readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly project="kata-containers"
 readonly tmp_dir=$(mktemp -d -t build-image-tmp.XXXXXXXXXX)
 readonly osbuilder_url=https://github.com/${project}/osbuilder.git
+export   GOPATH="${tmp_dir}/go"
 
 export GOPATH=${GOPATH:-${HOME}/go}
 source "${script_dir}/../../scripts/lib.sh"
+
+exit_handler() {
+	[ -d "${tmp_dir}" ] && sudo rm -rf "$tmp_dir"
+}
+trap exit_handler EXIT
 
 arch_target="$(uname -m)"
 
@@ -47,6 +53,7 @@ build_image() {
 	sudo -E PATH="${PATH}" make image \
 		DISTRO="${img_distro}" \
 		DEBUG="${DEBUG:-}" \
+		USE_DOCKER="1" \
 		AGENT_VERSION="${agent_version}" \
 		IMG_OS_VERSION="${img_os_version}" \
 		DISTRO_ROOTFS="${tmp_dir}/rootfs-image"

--- a/obs-packaging/kata-containers-image/update.sh
+++ b/obs-packaging/kata-containers-image/update.sh
@@ -48,8 +48,7 @@ replace_list=(
 
 verify
 rm -rf kata-containers.tar.gz
-image_tarball=$(find . -name 'kata-containers-'"${VERSION}"'-*.tar.gz')
-[ -f "${image_tarball}" ] || die "image not found"
+image_tarball=$(find . -name 'kata-containers-'"${VERSION}"'-'"${kata_proxy_hash:0:11}"'-*.tar.gz') [ -f "${image_tarball}" ] || die "image not found"
 cp "${image_tarball}" kata-containers.tar.gz
 
 check_image

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -82,3 +82,8 @@ build_hub() {
 	./script/build -o "${hub_bin}"
 	popd >>/dev/null
 }
+
+get_kata_hash_from_tag() {
+	repo=$1
+	git ls-remote --tags "https://github.com/${project}/${repo}.git" | grep "refs/tags/${kata_version}^{}" | awk '{print $1}'
+}


### PR DESCRIPTION
Fix image generation, instead of use the source code in the
host we clone it all the time to make sure we use a fresh
and clean agent repository when we generate the image.

Make sure that the agent `commit id` is the correct before
push to github or OBS.

Fixes: #166