### PR TITLE
obs: proxy: use DESTDIR variable.

### DIFF
--- a/obs-packaging/proxy/debian.rules-template
+++ b/obs-packaging/proxy/debian.rules-template
@@ -20,4 +20,4 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir debian/kata-proxy
-	make install LIBEXECDIR=$(shell pwd)/debian/kata-proxy/usr/libexec COMMIT=@HASH@
+	make install DESTDIR=$(shell pwd)/debian/kata-proxy COMMIT=@HASH@

--- a/obs-packaging/proxy/kata-proxy.spec-template
+++ b/obs-packaging/proxy/kata-proxy.spec-template
@@ -69,7 +69,7 @@ echo "Clean build root"
 rm -rf %{buildroot}
 
 %install
-make install LIBEXECDIR=%{buildroot}%{LIBEXECDIR} COMMIT=@HASH@
+make install DESTDIR=%{buildroot} COMMIT=@HASH@
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
Proxy respository now honor DESTDIR variable.

Fixes: #172