### PR TITLE
Makefile: Do not error out on "make clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ snap-xbuild:
 	cd $(MK_DIR)/snap-build; ./xbuild.sh -a all
 
 clean:
-	rm $(SNAPCRAFT_FILE)
+	rm -f $(SNAPCRAFT_FILE)
 
 .PHONY: test test-release-tools test-static-build test-packaging-tools snap clean \
 	$(VERSION_FILE) $(VERSIONS_YAML_FILE)


### PR DESCRIPTION
"make clean" errors out if snap/snapcraft.yaml file
does not exsist and the recipe for target 'clean'
fails. Avoid this my adding a "-f" option to rm to
have a clean state.

Fixes: #187

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com