### PR TITLE
obs-packaging: Fix "make test-packaging-tools" failure

### DIFF
--- a/obs-packaging/scripts/obs-docker.sh
+++ b/obs-packaging/scripts/obs-docker.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-_obs_docker_packaging_repo_dir=$(cd $(basename "${BASH_SOURCE[0]}"/../..) && pwd)
+_obs_docker_packaging_repo_dir=$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../.. && pwd)
 GO_ARCH=$(go env GOARCH)
 
 docker_run() {


### PR DESCRIPTION
unable to prepare context, unable to evaluate symlinks
in context path when building target test-packaging-tools
on ppc64le.

Fixes: #189

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com