### PR TITLE
obs-packaging: fix runtime qemu-* required version

### DIFF
--- a/obs-packaging/runtime/update.sh
+++ b/obs-packaging/runtime/update.sh
@@ -67,12 +67,12 @@ KATA_IMAGE_REQUIRED_VERSION=$(pkg_version "${kata_osbuilder_version}" "${KATA_CO
 info "image ${KATA_IMAGE_REQUIRED_VERSION}"
 
 KATA_CONTAINERS_QEMU_LITE_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/qemu-lite")
-KATA_QEMU_LITE_REQUIRED_VERSION=$(pkg_version "${qemu_lite_version}" "${KATA_CONTAINERS_QEMU_LITE_RELEASE}" "")
-info "image ${KATA_QEMU_LITE_REQUIRED_VERSION}"
+KATA_QEMU_LITE_REQUIRED_VERSION=$(pkg_version "${qemu_lite_version}" "${KATA_CONTAINERS_QEMU_LITE_RELEASE}" "${qemu_lite_hash}")
+info "qemu-lite ${KATA_QEMU_LITE_REQUIRED_VERSION}"
 
 KATA_CONTAINERS_QEMU_VANILLA_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/qemu-vanilla")
-KATA_QEMU_VANILLA_REQUIRED_VERSION=$(pkg_version "${qemu_vanilla_version}" "${KATA_CONTAINERS_QEMU_VANILLA_RELEASE}" "")
-info "image ${KATA_QEMU_VANILLA_REQUIRED_VERSION}"
+KATA_QEMU_VANILLA_REQUIRED_VERSION=$(pkg_version "${qemu_vanilla_version}" "${KATA_CONTAINERS_QEMU_VANILLA_RELEASE}" "${qemu_vanilla_hash}")
+info "qemu-vanilla ${KATA_QEMU_VANILLA_REQUIRED_VERSION}"
 
 PROJECT_REPO=${PROJECT_REPO:-home:${OBS_PROJECT}:${OBS_SUBPROJECT}/runtime}
 RELEASE=$(get_obs_pkg_release "${PROJECT_REPO}")


### PR DESCRIPTION
The kata-runtime spec file, when specifying a `Requires:` version for
qemu-lite and qemu-vanilla, does not include the "+git.<commit hash>"
part.
As a result of this, versions of kata-runtime and qemu installed on a
system using RPM package management may be inconsistent.

Fixes: #193

Signed-off-by: Marco Vedovati <mvedovati@suse.com>