### PR TITLE
kernel: Set the right PROJECT_REPO name in update.sh

### DIFF
--- a/obs-packaging/kernel/update.sh
+++ b/obs-packaging/kernel/update.sh
@@ -40,7 +40,7 @@ STATIC_FILES=(debian.dirs debian.rules debian.compat debian.copyright)
 cli "$@"
 
 [ "$VERBOSE" == "true" ] && set -x
-PROJECT_REPO=${PROJECT_REPO:-home:${OBS_PROJECT}:${OBS_SUBPROJECT}/linux-container}
+PROJECT_REPO=${PROJECT_REPO:-home:${OBS_PROJECT}:${OBS_SUBPROJECT}/kernel}
 RELEASE=$(get_obs_pkg_release "${PROJECT_REPO}")
 ((RELEASE++))
 


### PR DESCRIPTION
Set the right PROJECT_REPO name 
in update.sh

Fixes: #199

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com