### PR TITLE
obs-packaging: Makefile: Use -prune to delete a directory

### DIFF
--- a/obs-packaging/Makefile
+++ b/obs-packaging/Makefile
@@ -5,4 +5,4 @@
 
 
 clean:
-	find . -maxdepth 2 -type d -name '*home:katacontainers*' -exec sudo rm -rf {} \;
+	find . -maxdepth 2 -type d -name '*home:katacontainers*' -prune -exec sudo rm -rf {} \;


### PR DESCRIPTION
make -f .obs-packaging/Makefile clean fails with
"No such file or directory" even after deleting the
files returned by find. Fix it by using -prune.

Fixes: #203

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com