### PR TITLE
create-repo-branch: Skip repo branch qemu-lite for non-amd64

### DIFF
--- a/obs-packaging/build_all.sh
+++ b/obs-packaging/build_all.sh
@@ -43,10 +43,6 @@ main() {
 
 	pushd "${script_dir}"
 	for p in "${OBS_PKGS_PROJECTS[@]}"; do
-		if [[ "$GO_ARCH" != "amd64" && "$p" == "qemu-lite" ]]; then
-			echo "Skipping packaging qemu-lite as its only for amd64 arch"
-			continue
-		fi
 		pushd "$p" >>/dev/null
 		update_cmd="./update.sh"
 		if [ -n "${PUSH}" ]; then

--- a/obs-packaging/scripts/obs-pkgs.sh
+++ b/obs-packaging/scripts/obs-pkgs.sh
@@ -7,7 +7,6 @@
 #Note:Lets update qemu and the kernel first, they take longer to build.
 #Note: runtime is build at the end to get the version from all its dependencies.
 OBS_PKGS_PROJECTS=(
-	qemu-lite
 	qemu-vanilla
 	kernel
 	kata-containers-image
@@ -16,3 +15,7 @@ OBS_PKGS_PROJECTS=(
 	ksm-throttler
 	runtime
 )
+
+if [ "$(uname -m)" == "x86_64" ]; then
+	OBS_PKGS_PROJECTS=("qemu-lite" "${OBS_PKGS_PROJECTS[@]}")
+fi


### PR DESCRIPTION
This script creates empty repos in OBS
but qemu-lite repo is not needed/used
for non-amd64 archs. Hence skip it.

Fixes: #206

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com