### PR TITLE
qemu-vanilla: Make spec-template file requirement arch-specific

### DIFF
--- a/obs-packaging/qemu-vanilla/qemu-vanilla.spec-template
+++ b/obs-packaging/qemu-vanilla/qemu-vanilla.spec-template
@@ -113,7 +113,11 @@ done
 %defattr(-,root,root,-)
 /usr/bin/qemu-vanilla-ga
 /usr/bin/qemu-vanilla-pr-helper
+%ifarch x86_64
 /usr/bin/qemu-vanilla-system-x86_64
+%else
+/usr/bin/qemu-vanilla-system-ppc64
+%endif
 /usr/bin/virtfs-vanilla-proxy-helper
 %dir /usr/libexec
 %dir /usr/libexec/qemu-vanilla


### PR DESCRIPTION
The spec-template file looks for x86 specific
files irrespective of the arch on which
packaging is done for.

Fixes: #216

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com