### PR TITLE
snap: fix build errors

### DIFF
--- a/snap/snapcraft.yaml.in
+++ b/snap/snapcraft.yaml.in
@@ -206,6 +206,7 @@ parts:
       - libltdl-dev
       - libcap-dev
       - libattr1-dev
+      - libfdt-dev
     override-build: |
       chmod +x ${SNAPCRAFT_STAGE}/qemu/scripts/configure-hypervisor.sh
       # static build


### PR DESCRIPTION
Add libfdt-dev as build dependency because of qemu requires it in ppc and arm.

fixes #97

Signed-off-by: Julio Montes <julio.montes@intel.com>