### PR TITLE
 golang version requirements for OBS packaging

### DIFF
--- a/obs-packaging/gen_versions_txt.sh
+++ b/obs-packaging/gen_versions_txt.sh
@@ -5,6 +5,7 @@
 #
 
 [ -z "${DEBUG}" ] || set -x
+set -e
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -40,7 +41,6 @@ gen_version_file() {
 	kernel_version=${kernel_version#v}
 
 	golang_version=$(get_from_kata_deps "languages.golang.meta.newest-version" "${kata_version}")
-	golang_version="1.10.2"
 	golang_sha256=$(curl -s -L "https://storage.googleapis.com/golang/go${golang_version}.linux-${ARCH}.tar.gz.sha256")
 
 	# - is not a valid char for rpmbuild

--- a/obs-packaging/runtime/debian.rules-template
+++ b/obs-packaging/runtime/debian.rules-template
@@ -27,7 +27,10 @@ override_dh_auto_build:
 	tar xzf /usr/src/packages/SOURCES/go$(GO_VERSION).linux-@GO_ARCH@.tar.gz -C /usr/src/packages/BUILD/local
 	ln -s /usr/src/packages/BUILD /usr/src/packages/BUILD/go/src/$(IMPORTNAME)
 	cd $(GOPATH)/src/$(IMPORTNAME)/; \
-	make QEMUPATH=/usr/bin/$(DEFAULT_QEMU) COMMIT=@HASH@
+	make \
+		QEMUPATH=/usr/bin/$(DEFAULT_QEMU) \
+		COMMIT=@HASH@ \
+		SKIP_GO_VERSION_CHECK=1
 
 override_dh_auto_install:
 	mkdir -p debian/$(PKG_NAME)
@@ -37,6 +40,7 @@ override_dh_auto_install:
 		DESTDIR=$(shell pwd)/debian/$(PKG_NAME)/ \
 		PREFIX=/usr \
 		COMMIT=@HASH@ \
-		QEMUPATH=/usr/bin/$(DEFAULT_QEMU)
+		QEMUPATH=/usr/bin/$(DEFAULT_QEMU) \
+		SKIP_GO_VERSION_CHECK=1
 
 	sed -i -e '/^initrd =/d' $(shell pwd)/debian/$(PKG_NAME)/usr/share/defaults/kata-containers/configuration.toml

--- a/obs-packaging/runtime/kata-runtime.spec-template
+++ b/obs-packaging/runtime/kata-runtime.spec-template
@@ -69,7 +69,10 @@ export GOPATH=$HOME/rpmbuild/BUILD/go/
 mkdir -p $HOME/rpmbuild/BUILD/go/src/%{DOMAIN}/%{ORG}
 ln -s $HOME/rpmbuild/BUILD/kata-runtime-%{version} $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
-make QEMUPATH=/usr/bin/%{DEFAULT_QEMU} COMMIT=@HASH@
+make \
+    QEMUPATH=/usr/bin/%{DEFAULT_QEMU} \
+    COMMIT=@HASH@  \
+    SKIP_GO_VERSION_CHECK=1
 
 %check
 export http_proxy=http://127.0.0.1:9/
@@ -88,6 +91,7 @@ make \
     PREFIX=/usr \
     QEMUPATH=/usr/bin/%{DEFAULT_QEMU} \
     COMMIT=@HASH@ \
+    SKIP_GO_VERSION_CHECK=1 \
     install
 sed -i -e '/^initrd =/d' %{buildroot}/usr/share/defaults/kata-containers/configuration.toml
 


### PR DESCRIPTION
- Skip golang version checking when building on OBS.
- Remove the hardcoded golang version in the version generation script.

Fixes: #242