### PR TITLE
Build all improvements

### DIFF
--- a/obs-packaging/build_all.sh
+++ b/obs-packaging/build_all.sh
@@ -18,7 +18,6 @@ source "${script_dir}/scripts/obs-pkgs.sh"
 
 PUSH=${PUSH:-""}
 LOCAL=${LOCAL:-""}
-PUSH_TO_OBS=""
 
 export BUILD_DISTROS=${BUILD_DISTROS:-xUbuntu_16.04}
 # Packaging use this variable instead of use git user value
@@ -29,17 +28,46 @@ export AUTHOR_EMAIL="${AUTHOR_EMAIL:-user@example.com}"
 usage() {
 	msg="${1:-}"
 	exit_code=$"${2:-0}"
+	if [ -n "${msg}" ]; then
+		local logPrefix=""
+		[ ${exit_code} != "0" ] && logPrefix="ERROR: "
+		echo -e "${logPrefix}${msg}\n"
+	fi
+
 	cat <<EOT
-${msg}
 Usage:
-${script_name} <kata-branch>
+${script_name} [-h | --help] <kata-branch> [PROJ1 PROJ2 ... ]
+
+Generate OBS packages sources for the kata projects, based on branch
+kata-branch.
+${script_name} processes all the kata projects by default; alternatively you can
+specify a subset of the projects as additional arguments.
+
+Environment variables:
+PUSH        When set, push the packages sources to the openSUSE build
+            service.
+
+LOCAL       When set, build the packages locally.
+
 EOT
 	exit "${exit_code}"
 }
 
 main() {
-	local branch="${1:-}"
-	[ -n "${branch}" ] || usage "missing branch" "1"
+	case "${1:-}" in
+		"-h"|"--help")
+			usage "" "0"
+			;;
+		-*)
+			usage "Invalid option: ${1:-}" "1"
+			;;
+		"")
+			usage "missing branch" "1"
+			;;
+		*)
+			branch="${1:-}"
+			;;
+	esac
 
 	shift
 	local projectsList=("$@")

--- a/obs-packaging/build_all.sh
+++ b/obs-packaging/build_all.sh
@@ -41,9 +41,13 @@ main() {
 	local branch="${1:-}"
 	[ -n "${branch}" ] || usage "missing branch" "1"
 
-	pushd "${script_dir}"
-	for p in "${OBS_PKGS_PROJECTS[@]}"; do
-		pushd "$p" >>/dev/null
+	shift
+	local projectsList=("$@")
+	[ "${#projectsList[@]}" = "0" ] && projectsList=("${OBS_PKGS_PROJECTS[@]}")
+
+	pushd "${script_dir}" >>/dev/null
+	for p in "${projectsList[@]}"; do
+		[ -d "$p" ] || usage "$p is not a valid project directory" "1"
 		update_cmd="./update.sh"
 		if [ -n "${PUSH}" ]; then
 			# push to obs
@@ -53,11 +57,13 @@ main() {
 			update_cmd+=" -l"
 		fi
 
-		echo "update ${p}"
+		echo "======= Updating ${p} ======="
+		pushd "$p" >>/dev/null
 		bash -c "${update_cmd} ${branch}"
 		popd >>/dev/null
+		echo ""
 	done
-	popd
+	popd >> /dev/null
 }
 
 main $@


### PR DESCRIPTION
Improve the usage output, and add the ability to specify a list of projects to process as extra arguments.

Before:
```
$ ./build_all.sh
missing branch
Usage:
build_all.sh <kata-branch>
```
After:
```
$ ./build_all.sh
ERROR: missing branch

Usage:
build_all.sh [-h | --help] <kata-branch> [PROJ1 PROJ2 ... ]

Generate OBS packages sources for the kata projects, based on branch
kata-branch.
build_all.sh processes all the kata projects by default; alternatively you can
specify a subset of the projects as additional arguments.

Environment variables:
PUSH        When set, push the packages sources to the openSUSE build
            service.

LOCAL       When set, build the packages locally.
```