### PR TITLE
obs-packaging: remove dh-modaliases deb requirement

### DIFF
--- a/obs-packaging/ksm-throttler/debian.control-template
+++ b/obs-packaging/ksm-throttler/debian.control-template
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Homepage: https://katacontainers.io
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases, pkg-config, dh-systemd, systemd
+Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, pkg-config, dh-systemd, systemd
 
 Package: kata-ksm-throttler
 Architecture: @deb_arch@

--- a/obs-packaging/ksm-throttler/kata-ksm-throttler.dsc-template
+++ b/obs-packaging/ksm-throttler/kata-ksm-throttler.dsc-template
@@ -6,7 +6,7 @@ Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Homepage: https://katacontainers.io
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases, pkg-config, dh-systemd, systemd
+Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, pkg-config, dh-systemd, systemd
 Debtransform-Tar: kata-ksm-throttler-@VERSION@.git+@HASH@.tar.gz
 
 Package: kata-ksm-throttler

--- a/obs-packaging/proxy/debian.control-template
+++ b/obs-packaging/proxy/debian.control-template
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Homepage: https://katacontainers.io
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases
+Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
 
 Package: kata-proxy
 Architecture: @deb_arch@

--- a/obs-packaging/proxy/kata-proxy.dsc-template
+++ b/obs-packaging/proxy/kata-proxy.dsc-template
@@ -5,7 +5,7 @@ Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases
+Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
 Homepage: https://katacontainers.io
 Debtransform-Tar: kata-proxy-@VERSION@+git.@HASH@.tar.gz
 

--- a/obs-packaging/runtime/debian.control-template
+++ b/obs-packaging/runtime/debian.control-template
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Homepage: https://katacontainers.io
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases
+Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
 
 Package: kata-runtime
 Architecture: @deb_arch@

--- a/obs-packaging/runtime/kata-runtime.dsc-template
+++ b/obs-packaging/runtime/kata-runtime.dsc-template
@@ -7,7 +7,7 @@ Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, dh-modaliases
+Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
 Homepage: https://katacontainers.io
 Debtransform-Tar: kata-runtime-@VERSION@+git.@HASH@.tar.gz
 

--- a/obs-packaging/shim/debian.control-template
+++ b/obs-packaging/shim/debian.control-template
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Homepage: https://katacontainers.io
-Build-Depends: debhelper (>= 9), git, ca-certificates, dh-modaliases, execstack, devscripts, dh-make
+Build-Depends: debhelper (>= 9), git, ca-certificates, execstack, devscripts, dh-make
 
 Package: kata-shim
 Architecture: @deb_arch@

--- a/obs-packaging/shim/kata-shim.dsc-template
+++ b/obs-packaging/shim/kata-shim.dsc-template
@@ -5,7 +5,7 @@ Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 9), git, ca-certificates, dh-modaliases, execstack, devscripts, dh-make
+Build-Depends: debhelper (>= 9), git, ca-certificates, execstack, devscripts, dh-make
 Homepage: https://katacontainers.io
 Debtransform-Tar: kata-shim-@VERSION@+git.@HASH@.tar.gz
 


### PR DESCRIPTION
Remove the redundant dh-modaliases package as a build requirement
for deb packages. This allows to build packages for the Debian distro.

I tested this change a OBS branch and builds for all Ubuntu and Debian are fine.

Fixes: #249
Related: #247 

