### PR TITLE
obs-packaging: multi-arch kernel build support

### DIFF
--- a/obs-packaging/linux-container/debian.rules
+++ b/obs-packaging/linux-container/debian.rules
@@ -3,14 +3,23 @@ include /usr/share/dpkg/default.mk
 KernelDir=debian/kata-linux-container/usr/share/kata-containers
 DebugDir=debian/kata-linux-container-debug/usr/share/kata-containers
 KernelVer=${DEB_VERSION_UPSTREAM_REVISION}.container
+HOST_ARCH=$(shell arch)
+KATA_MULTIARCH="/usr/src/packages/SOURCES/kata-multiarch.sh"
+KERNEL_ARCH=$(shell /bin/bash $(KATA_MULTIARCH) -a $(HOST_ARCH))
+KERNEL_IMAGE=$(shell /bin/bash $(KATA_MULTIARCH) -i $(HOST_ARCH))
+KERNEL_CONFIGS=kata-kernel-configs
+
 %:
 	dh $@
 
 override_dh_auto_build:
 	sed -i "s/^EXTRAVERSION.*/EXTRAVERSION = -$$(echo $(KernelVer) | cut -d'-' -f2)/" Makefile
-	cp /usr/src/packages/SOURCES/config .config
-	make -s ARCH=x86_64 oldconfig > /dev/null
-	make -s CONFIG_DEBUG_SECTION_MISMATCH=y ARCH=x86_64 -j4 all
+	tar xzf /usr/src/packages/SOURCES/$(KERNEL_CONFIGS).tar.gz
+	rm -f .config
+	find $(KERNEL_CONFIGS) -name "$(KERNEL_ARCH)_kata_kvm_*" -exec cp {} .config \;
+	[ -f .config ] || (@echo "ERROR: cannot find the kernel config file for the $(KERNEL_ARCH) architecture"; exit 1)
+	make -s ARCH=$(KERNEL_ARCH) oldconfig > /dev/null
+	make -s CONFIG_DEBUG_SECTION_MISMATCH=y ARCH=$(KERNEL_ARCH) -j all
 
 override_dh_auto_install:
 
@@ -22,10 +31,11 @@ override_dh_install:
 	mkdir -p $(KernelDir)
 	install -m 644 .config $(DebugDir)/config-$(KernelVer)
 	install -m 644 System.map $(DebugDir)/System.map-$(KernelVer)
-	cp arch/x86/boot/bzImage $(KernelDir)/vmlinuz-$(KernelVer)
-	chmod 755 $(KernelDir)/vmlinuz-$(KernelVer)
-	ln -sf vmlinuz-$(KernelVer) $(KernelDir)/vmlinuz.container
-
+	if [ -n "$(KERNEL_IMAGE)" ]; then \
+		cp $$(realpath $(KERNEL_IMAGE))  $(KernelDir)/vmlinuz-$(KernelVer); \
+		chmod 755 $(KernelDir)/vmlinuz-$(KernelVer); \
+		ln -sf vmlinuz-$(KernelVer) $(KernelDir)/vmlinuz.container; \
+	fi
 	cp vmlinux $(KernelDir)/vmlinux-$(KernelVer)
 	chmod 755 $(KernelDir)/vmlinux-$(KernelVer)
 	ln -sf vmlinux-$(KernelVer) $(KernelDir)/vmlinux.container

--- a/obs-packaging/linux-container/kata-linux-container.spec-template
+++ b/obs-packaging/linux-container/kata-linux-container.spec-template
@@ -4,17 +4,16 @@
 # This specialization allows us to optimize memory footprint and boot time.
 #
 
-%define bzimage_arch x86
-
 Name:           kata-linux-container
 Version:        @VERSION@.@CONFIG_VERSION@
 Release:        @RELEASE@.<B_CNT>
 License:        GPL-2.0
 Summary:        The Linux kernel optimized for running inside a container
+Group:          System/Kernel
 Url:            http://www.kernel.org/
-Group:          kernel
 Source0:        https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-@VERSION@.tar.xz
-Source1:        config
+Source1:        kata-kernel-configs.tar.gz
+Source2:        kata-multiarch.sh
 
 %define kversion %{version}-%{release}.container
 
@@ -52,8 +51,8 @@ BuildRequires:  bison
 The Linux kernel.
 
 %package debug
-Summary: Debug components for the kata-linux-container package
-Group: Default
+Summary: Debug components for the %{name} package
+Group:   System/Kernel
 
 %description debug
 Debug components for the kata-linux-container package.
@@ -61,26 +60,27 @@ This package includes the kernel config and the kernel map.
 
 %prep
 %setup -q -n linux-@VERSION@
+%setup -q -T -D -n linux-@VERSION@ -a 1
+cp %{SOURCE2} .
+chmod +x $(basename %{SOURCE2})
 
 # Patches
 @RPM_APPLY_PATCHES@
 
-cp %{SOURCE1} .
-
 %build
+
 BuildKernel() {
-
-    Arch=%{_arch}
+    local kernelArch=$(./kata-multiarch.sh -a %{_arch})
     ExtraVer="-%{release}.container"
-
-    %ifarch ppc64le
-    Arch=powerpc
-    %endif
 
     perl -p -i -e "s/^EXTRAVERSION.*/EXTRAVERSION = ${ExtraVer}/" Makefile
 
     make -s mrproper
-    cp config .config
+
+    # Runtime .config selection based on kernelArch
+    rm -f .config
+    find kata-kernel-configs -name "${kernelArch}_kata_kvm_*" -exec cp {} .config \;
+	[ -f .config ] || (echo "ERROR: cannot find the kernel config file for the ${kernelArch} architecture"; exit 1)
 
     %if 0%{?fedora}
     #Fedora uses gcc 8, build is failing due to warnings.
@@ -88,8 +88,8 @@ BuildKernel() {
     export EXTRA_CFLAGS="-Wno-format-truncation -Wno-cast-function-type -Wno-error=restrict -Wno-error"
     %endif
 
-    make -s ARCH=$Arch oldconfig > /dev/null
-    make -s CONFIG_DEBUG_SECTION_MISMATCH=y %{?_smp_mflags} ARCH=$Arch %{?sparse_mflags} || exit 1
+    make -s ARCH=$kernelArch oldconfig > /dev/null
+    make -s CONFIG_DEBUG_SECTION_MISMATCH=y %{?_smp_mflags} ARCH=$kernelArch %{?sparse_mflags} || exit 1
 }
 
 BuildKernel
@@ -97,22 +97,20 @@ BuildKernel
 %install
 
 InstallKernel() {
-    KernelImage=$1
-    KernelImageRaw=$2
-
-    Arch=%{_arch}
+    compressedImage=$(./kata-multiarch.sh -i %{_arch})
+    rawImage="vmlinux"
     KernelVer=%{kversion}
     KernelDir=%{buildroot}/usr/share/kata-containers
 
     mkdir   -p ${KernelDir}
 
-    %ifarch x86_64
-    cp $KernelImage ${KernelDir}/vmlinuz-$KernelVer
-    chmod 755 ${KernelDir}/vmlinuz-$KernelVer
-    ln -sf vmlinuz-$KernelVer ${KernelDir}/vmlinuz.container
-    %endif
+    if [ -n "$compressedImage" ]; then
+        cp "$compressedImage" ${KernelDir}/vmlinuz-$KernelVer
+        chmod 755 ${KernelDir}/vmlinuz-$KernelVer
+        ln -sf vmlinuz-$KernelVer ${KernelDir}/vmlinuz.container
+    fi
 
-    cp $KernelImageRaw ${KernelDir}/vmlinux-$KernelVer
+    cp $rawImage ${KernelDir}/vmlinux-$KernelVer
     chmod 755 ${KernelDir}/vmlinux-$KernelVer
     ln -sf vmlinux-$KernelVer ${KernelDir}/vmlinux.container
 
@@ -123,11 +121,7 @@ InstallKernel() {
     rm -f %{buildroot}/usr/lib/modules/$KernelVer/source
 }
 
-%ifarch ppc64le
-InstallKernel $(realpath vmlinux) $(realpath vmlinux)
-%else
-InstallKernel arch/%{bzimage_arch}/boot/bzImage vmlinux
-%endif
+InstallKernel
 
 rm -rf %{buildroot}/usr/lib/firmware
 
@@ -139,7 +133,8 @@ rm -rf %{buildroot}/usr/lib/firmware
 %dir /usr/share/kata-containers
 /usr/share/kata-containers/vmlinux-%{kversion}
 /usr/share/kata-containers/vmlinux.container
-%ifarch x86_64
+
+%ifnarch ppc64le
 /usr/share/kata-containers/vmlinuz-%{kversion}
 /usr/share/kata-containers/vmlinuz.container
 %endif

--- a/obs-packaging/linux-container/kata-multiarch.sh
+++ b/obs-packaging/linux-container/kata-multiarch.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Convert architecture to the name used by the Linux kernel build system
+arch_to_kernel() {
+	local -r arch="$1"
+
+	case "${arch}" in
+		aarch64) echo "arm64";;
+		ppc64le) echo "powerpc";;
+		s390|s390x) echo "s390";;
+		x86_64) echo "${arch}";;
+		*) echo "unsupported architecture: ${arch}" >&2; exit 1;;
+	esac
+}
+
+# Convert architecture to the location of the compressed linux image
+arch_to_image() {
+	local -r arch="$1"
+	case "${arch}" in
+		aarch64)
+			echo "arch/arm64/boot/Image"
+			;;
+		ppc64le)
+			# No compressed image
+			;;
+		s390|s390x)
+			echo "arch/s390/boot/image"
+			;;
+		*)
+			echo "arch/${arch}/boot/bzImage"
+			;;
+	esac
+}
+
+usage() {
+	echo "$(basename $0) FLAG ARCHITECTURE"
+	echo "Allowed flags:"
+	echo "    -a :    Print kernel architecture"
+	echo "    -i :    Print kernel compressed image location (may be empty)"
+}
+
+if [ "$#" != "2" ]; then
+	echo -e "Invalid options\n\n$(usage)" >&2
+	exit 1
+fi
+
+case "$1" in
+	-a)
+		arch_to_kernel $2
+		;;
+	-i)
+		arch_to_image $2
+		;;
+	*)
+		echo -e "Invalid options\n\n$(usage)" >&2
+		exit 1
+		;;
+esac

--- a/obs-packaging/linux-container/update.sh
+++ b/obs-packaging/linux-container/update.sh
@@ -32,8 +32,10 @@ KR_PATCHES=$(eval find "${SCRIPT_DIR}/../../kernel/patches" -type f -name "*.pat
 KR_REL=https://www.kernel.org/releases.json
 KR_SHA=https://cdn.kernel.org/pub/linux/kernel/v"${KR_SERIES}"/sha256sums.asc
 
-GENERATED_FILES=(kata-linux-container.dsc kata-linux-container.spec _service config debian.control)
-STATIC_FILES=(debian.dirs debian.rules debian.compat debian.copyright)
+KR_CONFIGS="kata-kernel-configs"
+
+GENERATED_FILES=(kata-linux-container.dsc kata-linux-container.spec _service debian.control ${KR_CONFIGS}.tar.gz)
+STATIC_FILES=(debian.dirs debian.rules debian.compat debian.copyright kata-multiarch.sh)
 #STATIC_FILES+=($KR_PATCHES)
 
 # Parse arguments
@@ -46,9 +48,10 @@ RELEASE=$(get_obs_pkg_release "${PROJECT_REPO}")
 
 kernel_sha256=$(curl -L -s -f ${KR_SHA} | awk '/linux-'${VERSION}'.tar.xz/ {print $1}')
 
-# Generate the kernel config file
-KERNEL_ARCH=$(go get github.com/kata-containers/tests && $GOPATH/src/github.com/kata-containers/tests/.ci/kata-arch.sh --kernel)
-cp "${SCRIPT_DIR}/../../kernel/configs/${KERNEL_ARCH}_kata_kvm_${KR_LTS}.x" config
+# Copy the kernel config files for all architecture
+mkdir -p configs
+readonly configs_dir="kernel/configs"
+find "${SCRIPT_DIR}/../../${configs_dir}" -name "*_kata_kvm_${KR_LTS}.x" -exec tar --transform="s,${configs_dir},${KR_CONFIGS}," -czf ${KR_CONFIGS}.tar.gz {} +
 
 replace_list=(
 	"VERSION=${VERSION}"


### PR DESCRIPTION
Update the kernel package to allow building for multiple architectures with
a single set of sources.
Changes:
- Add kernel configs for all architectures
- Detect at runtime the correct target architecture and kernel
compressed image location. This is done  with the script kata-multiarch.sh.
    
Note that debian control files still need to be updated to handle Multi-Arch,
so that they are not tied to the architecture on which
`linux-container/update.sh` is run.

Fixes: #262