### PR TITLE
snap: skip go version check

### DIFF
--- a/snap/snapcraft.yaml.in
+++ b/snap/snapcraft.yaml.in
@@ -26,10 +26,12 @@ parts:
       export GOPATH=$(realpath ../go)
       cd ${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/runtime
       make \
-        PREFIX=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr
+        PREFIX=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr \
+        SKIP_GO_VERSION_CHECK=1
       make install \
         PREFIX=/usr \
-        DESTDIR=${SNAPCRAFT_PART_INSTALL}
+        DESTDIR=${SNAPCRAFT_PART_INSTALL} \
+        SKIP_GO_VERSION_CHECK=1
       sed -i -e '/^image =/d' ${SNAPCRAFT_PART_INSTALL}/usr/share/defaults/${SNAPCRAFT_PROJECT_NAME}/configuration.toml
 
   proxy:

--- a/snap/snapcraft.yaml.in
+++ b/snap/snapcraft.yaml.in
@@ -25,7 +25,6 @@ parts:
       unset GOROOT
       export GOPATH=$(realpath ../go)
       cd ${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/runtime
-      QEMU_ARCH=$(arch)
       make \
         PREFIX=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr
       make install \


### PR DESCRIPTION
Right golang version is installed before building kata-containers, skip go
version check to avoid including extra build dependencies.

fixes #265

Signed-off-by: Julio Montes <julio.montes@intel.com>