### PR TITLE
obs-packaging: support comparisons of pre-releases versions

### DIFF
--- a/obs-packaging/gen_versions_txt.sh
+++ b/obs-packaging/gen_versions_txt.sh
@@ -139,7 +139,9 @@ main() {
 	if [ -n "$compareOnly" ]; then
 		source "./${versions_txt}" || exit 1
 		[ -n "${kata_version}" ] || die "${version_file} does not contain a valid kata_version variable"
-		[ "$(get_kata_version $branch)" = "${kata_version}" ] && compare_result="matches" || compare_result="is different from"
+		# Replacing ~ with -, as - is not a valid char for rpmbuild
+		# see https://github.com/semver/semver/issues/145
+		[ "$(get_kata_version $branch)" = "${kata_version/\~/-}" ] && compare_result="matches" || compare_result="is different from"
 		echo "${kata_version} in ${versions_txt} ${compare_result} the version at branch ${branch}"
 		return
 	fi


### PR DESCRIPTION
Fix version compare when specifying a pre-release version in
versions.txt. This is needed because kata on git uses strict semver,
while kata RPM packages uses ~ in place of - for PATCH version, to
allow RPM version comparison to work properly.

Fixes: #285

Signed-off-by: Marco Vedovati <mvedovati@suse.com>