### PR TITLE
Update list of stable release distros

### DIFF
--- a/obs-packaging/distros
+++ b/obs-packaging/distros
@@ -11,5 +11,7 @@ Fedora_29::Fedora:29::standard
 RHEL_7::RedHat:RHEL-7::standard
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 openSUSE_Leap_42.3::openSUSE:Leap:42.3::standard
+openSUSE_Leap_15.0::openSUSE:Leap:15.0::standard
+openSUSE_Tumbleweed::openSUSE:Factory::snapshot
 xUbuntu_16.04::Ubuntu:16.04::universe
 xUbuntu_18.04::Ubuntu:18.04::universe

--- a/obs-packaging/distros
+++ b/obs-packaging/distros
@@ -6,13 +6,10 @@
 #
 CentOS_7::CentOS:CentOS-7::standard
 Debian_9::Debian:9.0::standard
-Fedora_26::Fedora:26::standard
-Fedora_27::Fedora:27::standard
 Fedora_28::Fedora:28::standard
 Fedora_29::Fedora:29::standard
 RHEL_7::RedHat:RHEL-7::standard
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 openSUSE_Leap_42.3::openSUSE:Leap:42.3::standard
 xUbuntu_16.04::Ubuntu:16.04::universe
-xUbuntu_17.10::Ubuntu:17.10::universe
 xUbuntu_18.04::Ubuntu:18.04::universe

--- a/obs-packaging/distros
+++ b/obs-packaging/distros
@@ -5,6 +5,7 @@
 #   name::project::repository
 #
 CentOS_7::CentOS:CentOS-7::standard
+Debian_9::Debian:9.0::standard
 Fedora_26::Fedora:26::standard
 Fedora_27::Fedora:27::standard
 Fedora_28::Fedora:28::standard


### PR DESCRIPTION
- Add Debian 9 (#289)
- Remove EOL (#279)
- Add recent openSUSE (Leap 15.0 and Tumbleweed).