### PR TITLE
release: 1.5.0 fixes

### DIFF
--- a/obs-packaging/ksm-throttler/kata-ksm-throttler.spec-template
+++ b/obs-packaging/ksm-throttler/kata-ksm-throttler.spec-template
@@ -26,9 +26,6 @@ License  : Apache-2.0
 
 BuildRequires: git
 BuildRequires: systemd
-%if 0%{?suse_version} && 0%{?is_opensuse}
-BuildRequires: openSUSE-release
-%endif
 
 # Patches
 @RPM_PATCH_LIST@

--- a/obs-packaging/linux-container/debian.rules
+++ b/obs-packaging/linux-container/debian.rules
@@ -19,7 +19,7 @@ override_dh_auto_build:
 	find $(KERNEL_CONFIGS) -name "$(KERNEL_ARCH)_kata_kvm_*" -exec cp {} .config \;
 	[ -f .config ] || (@echo "ERROR: cannot find the kernel config file for the $(KERNEL_ARCH) architecture"; exit 1)
 	make -s ARCH=$(KERNEL_ARCH) oldconfig > /dev/null
-	make -s CONFIG_DEBUG_SECTION_MISMATCH=y ARCH=$(KERNEL_ARCH) -j all
+	make -s CONFIG_DEBUG_SECTION_MISMATCH=y ARCH=$(KERNEL_ARCH)
 
 override_dh_auto_install:
 

--- a/obs-packaging/runtime/debian.rules-template
+++ b/obs-packaging/runtime/debian.rules-template
@@ -28,7 +28,7 @@ override_dh_auto_build:
 	ln -s /usr/src/packages/BUILD /usr/src/packages/BUILD/go/src/$(IMPORTNAME)
 	cd $(GOPATH)/src/$(IMPORTNAME)/; \
 	make \
-		QEMUPATH=/usr/bin/$(DEFAULT_QEMU) \
+		QEMUCMD=$(DEFAULT_QEMU) \
 		COMMIT=@HASH@ \
 		SKIP_GO_VERSION_CHECK=1
 
@@ -40,7 +40,7 @@ override_dh_auto_install:
 		DESTDIR=$(shell pwd)/debian/$(PKG_NAME)/ \
 		PREFIX=/usr \
 		COMMIT=@HASH@ \
-		QEMUPATH=/usr/bin/$(DEFAULT_QEMU) \
+		QEMUCMD=$(DEFAULT_QEMU) \
 		SKIP_GO_VERSION_CHECK=1
 
 	sed -i -e '/^initrd =/d' $(shell pwd)/debian/$(PKG_NAME)/usr/share/defaults/kata-containers/configuration.toml

--- a/obs-packaging/runtime/kata-runtime.spec-template
+++ b/obs-packaging/runtime/kata-runtime.spec-template
@@ -25,9 +25,6 @@ Group    : Development/Tools
 License  : Apache-2.0
 
 BuildRequires: git
-%if 0%{?suse_version} && 0%{?is_opensuse}
-BuildRequires: openSUSE-release
-%endif
 
 %{!?el7 || !?suse_version:Requires: qemu-lite >= @qemu_lite_obs_fedora_version@ }
 
@@ -55,11 +52,10 @@ Overview
 %prep
 mkdir local
 tar -C local -xzf ../SOURCES/go%{GO_VERSION}.linux-@GO_ARCH@.tar.gz
+%autosetup -N -S git
 # Patches
 @RPM_APPLY_PATCHES@
 
-%setup -q
-%autosetup -S git
 
 %build
 export GOROOT=$HOME/rpmbuild/BUILD/local/go

--- a/obs-packaging/runtime/kata-runtime.spec-template
+++ b/obs-packaging/runtime/kata-runtime.spec-template
@@ -66,7 +66,7 @@ mkdir -p $HOME/rpmbuild/BUILD/go/src/%{DOMAIN}/%{ORG}
 ln -s $HOME/rpmbuild/BUILD/kata-runtime-%{version} $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 make \
-    QEMUPATH=/usr/bin/%{DEFAULT_QEMU} \
+    QEMUCMD=%{DEFAULT_QEMU} \
     COMMIT=@HASH@  \
     SKIP_GO_VERSION_CHECK=1
 
@@ -85,7 +85,7 @@ cd $HOME/rpmbuild/BUILD/go/src/%{IMPORTNAME}
 make \
     DESTDIR=%{buildroot} \
     PREFIX=/usr \
-    QEMUPATH=/usr/bin/%{DEFAULT_QEMU} \
+    QEMUCMD=%{DEFAULT_QEMU} \
     COMMIT=@HASH@ \
     SKIP_GO_VERSION_CHECK=1 \
     install

--- a/obs-packaging/runtime/kata-runtime.spec-template
+++ b/obs-packaging/runtime/kata-runtime.spec-template
@@ -105,7 +105,7 @@ sed -i -e '/^initrd =/d' %{buildroot}/usr/share/defaults/kata-containers/configu
 /usr/bin/kata-collect-data.sh
 /usr/share/defaults/
 /usr/share/defaults/kata-containers/
-/usr/share/defaults/kata-containers/configuration.toml
+/usr/share/defaults/kata-containers/configuration*.toml
 /usr/share/bash-completion
 /usr/share/bash-completion/completions
 /usr/share/bash-completion/completions/kata-runtime

--- a/obs-packaging/versions.txt
+++ b/obs-packaging/versions.txt
@@ -1,24 +1,24 @@
 # This is a generated file from gen_versions_txt.sh
 
-kata_version=1.5.0~rc2
+kata_version=1.5.0
 
-kata_runtime_version=1.5.0~rc2
-kata_runtime_hash=b954eecad14de13e09dfab89a8b902f1cb05a041
+kata_runtime_version=1.5.0
+kata_runtime_hash=5f7fcd773089a615b776862f92217e987f06df0a
 
-kata_proxy_version=1.5.0~rc2
-kata_proxy_hash=2029708f472b91e8167081ea87974b268589c8ab
+kata_proxy_version=1.5.0
+kata_proxy_hash=9e77a0b1925d1ab3afda7d46ec256be8a9cff222
 
-kata_shim_version=1.5.0~rc2
-kata_shim_hash=4138b29661d044a298924ba60c5fd79a8b213862
+kata_shim_version=1.5.0
+kata_shim_hash=efbf3bb25065ce89099630b753d218cdc678e758
 
-kata_agent_version=1.5.0~rc2
-kata_agent_hash=91a87bc7176750eee2f032aa564e8b28f4ad0e73
+kata_agent_version=1.5.0
+kata_agent_hash=a581aebf47386df570f796cb835bd23820448b9b
 
-kata_ksm_throttler_version=1.5.0~rc2
-kata_ksm_throttler_hash=d70af5c5f84549a68fcf67ab744ace2c83ac632d
+kata_ksm_throttler_version=1.5.0
+kata_ksm_throttler_hash=3dd4c9f8b494ebd79aa0685d56891e5cdab69d2b
 
 # Dependencies
-kata_osbuilder_version=1.5.0~rc2
+kata_osbuilder_version=1.5.0
 
 qemu_lite_version=2.11.0
 qemu_lite_hash=87517afd726526e6e32a3e0be07eca34b8cc6962

--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -145,6 +145,21 @@ install_kata_components() {
 	pushd "${destdir}/${prefix}/share/defaults/${project}"
 	ln -sf "configuration-qemu.toml" configuration.toml
 	popd
+
+	pushd "${destdir}/${prefix}/bin"
+	cat <<EOT | sudo tee kata-fc
+#!/bin/bash
+${prefix}/bin/kata-runtime --kata-config "${prefix}/share/defaults/${project}/configuration-fc.toml" \$@
+EOT
+	sudo chmod +x kata-fc
+
+	cat <<EOT | sudo tee kata-qemu
+#!/bin/bash
+${prefix}/bin/kata-runtime --kata-config "${prefix}/share/defaults/${project}/configuration-qemu.toml" \$@
+EOT
+	sudo chmod +x kata-qemu
+
+	popd
 }
 
 main() {

--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -115,10 +115,10 @@ install_qemu() {
 # Install static firecracker asset
 install_firecracker() {
 	info "build static firecracker"
-	"${script_dir}/../static-build/firecracker/build-static-firecracker.sh"
+	[ -f "firecracker/firecracker-static" ] || "${script_dir}/../static-build/firecracker/build-static-firecracker.sh"
 	info "Install static firecracker"
-		mkdir -p "${destdir}/opt/kata/bin/"
-		install -D --owner root --group root --mode 0744  firecracker-static "${destdir}/opt/kata/bin/firecracker"
+	mkdir -p "${destdir}/opt/kata/bin/"
+	sudo install -D --owner root --group root --mode 0744  firecracker/firecracker-static "${destdir}/opt/kata/bin/firecracker"
 
 }
 
@@ -165,6 +165,7 @@ main() {
 	install_kata_components
 	install_kernel
 	install_qemu
+	install_firecracker
 	tarball_name="${destdir}.tar.xz"
 	pushd "${destdir}" >>/dev/null
 	tar cfJ "${tarball_name}" "./opt"

--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -140,7 +140,8 @@ install_kata_components() {
 			install
 		popd >>/dev/null
 	done
-	sed -i -e '/^initrd =/d' "${destdir}/${prefix}/share/defaults/${project}/configuration.toml"
+	sed -i -e '/^initrd =/d' "${destdir}/${prefix}/share/defaults/${project}/configuration-qemu.toml"
+	sed -i -e '/^initrd =/d' "${destdir}/${prefix}/share/defaults/${project}/configuration-fc.toml"
 }
 
 main() {

--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -142,6 +142,9 @@ install_kata_components() {
 	done
 	sed -i -e '/^initrd =/d' "${destdir}/${prefix}/share/defaults/${project}/configuration-qemu.toml"
 	sed -i -e '/^initrd =/d' "${destdir}/${prefix}/share/defaults/${project}/configuration-fc.toml"
+	pushd "${destdir}/${prefix}/share/defaults/${project}"
+	ln -sf "configuration-qemu.toml" configuration.toml
+	popd
 }
 
 main() {

--- a/release/runtime-release-notes.sh
+++ b/release/runtime-release-notes.sh
@@ -145,7 +145,7 @@ More information [Limitations][limitations]
 [image]: https://github.com/kata-containers/osbuilder/releases/tag/${runtime_version}
 [ocispec]: https://github.com/opencontainers/runtime-spec/releases/tag/${oci_spec_version}
 [limitations]: https://github.com/kata-containers/documentation/blob/master/Limitations.md
-[installation]: https://github.com/kata-containers/documentation/blob/${new_release}/install/README.md
+[installation]: https://github.com/kata-containers/documentation/tree/master/install
 EOT
 }
 


### PR DESCRIPTION
### releaes: static: add wrapper for firecracker config.                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support                                                                                                                                                               
                                                                                                                                                                                                                                                                                
The wiki says that a wrapper is part of the release tarball,  `make install`                                                                                                                                                                                                    
from runtime is not doing it, add workaround until this is added as an official wrapper.                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
### static: release: add correct symlink until is fixed                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                
dest dir is broken and symlink is created on the host not the tarbal.                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                
See:                                                                                                                                                                                                                                                                            
https://github.com/kata-containers/runtime/issues/1161                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                
### release: static: add firecracker to tarball.                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
The firecracker binary was not added to release tarball.                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
### pkgs: runtime: spec fix qemu path                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                
QEMUCMD is used to identify the defauly hypervisor on kata.                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                
### pkgs: Fix spec file.                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
- Remove not needed require                                                                                                                                                                                                                                                     
- call %autosetup before apply patches.                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                
### pkgs: runtime: fix make install                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                
Make install got broken on last release, fix it locally.                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
See:                                                                                                                                                                                                                                                                            
https://github.com/kata-containers/runtime/issues/1161                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
### pkg: spec: add all files that match as config file.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                
New hypervisor configs could be added in the future, add                                                                                                                                                                                                                        
any possible new config file.                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                
### deploy: release: Fix config paths                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                
Now there are 2 config paths lets update both to not use                                                                                                                                                                                                                        
initrd by default.                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                
### pkgs: Update version for kata 1.5.0                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                
Update versions file as part of release process.                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
### pkgs: debian: fix kernel build.                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                
Dont use -j all, it may lead the builder workers run out of memory.   