### PR TITLE
Firecracker: Add support for firecracker packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ test-release-tools:
 
 test-static-build:
 	@make -f $(MK_DIR)/static-build/qemu/Makefile
+	@make -f $(MK_DIR)/static-build/firecracker/Makefile
 
 test-packaging-tools:
 	@$(MK_DIR)/obs-packaging/build_from_docker.sh

--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -112,6 +112,16 @@ install_qemu() {
 	tar xf kata-qemu-static.tar.gz -C "${destdir}"
 }
 
+# Install static firecracker asset
+install_firecracker() {
+	info "build static firecracker"
+	"${script_dir}/../static-build/firecracker/build-static-firecracker.sh"
+	info "Install static firecracker"
+		mkdir -p "${destdir}/opt/kata/bin/"
+		install -D --owner root --group root --mode 0744  firecracker-static "${destdir}/opt/kata/bin/firecracker"
+
+}
+
 #Install all components that are not assets
 install_kata_components() {
 	for p in "${projects[@]}"; do

--- a/static-build/firecracker/Makefile
+++ b/static-build/firecracker/Makefile
@@ -1,0 +1,9 @@
+MK_DIR :=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+CONFIG_DIR := $(MK_DIR)/../../scripts/
+
+build:
+	"$(MK_DIR)/build-static-firecracker.sh"
+
+clean:
+	rm -rf "$(MK_DIR)/firecracker"
+	rm "$(MK_DIR)/firecracker-static"

--- a/static-build/firecracker/build-static-firecracker.sh
+++ b/static-build/firecracker/build-static-firecracker.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+config_dir="${script_dir}/../../scripts/"
+
+firecracker_repo="${firecracker_repo:-}"
+firecracker_version="${firecracker_version:-}"
+
+if [ -z "$firecracker_repo" ]; then
+	info "Get firecracker information from runtime versions.yaml"
+        firecracker_url=$(get_from_kata_deps "assets.hypervisor.firecracker.url")
+	[ -n "$firecracker_url" ] || die "failed to get firecracker url"
+        firecracker_repo="${firecracker_url}.git"
+fi
+[ -n "$firecracker_repo" ] || die "failed to get firecracker repo"
+
+[ -n "$firecracker_version" ] || firecracker_version=$(get_from_kata_deps "assets.hypervisor.firecracker.version")
+[ -n "$firecracker_version" ] || die "failed to get firecracker version"
+
+info "Build ${firecracker_repo} version: ${firecracker_version}"
+
+git clone ${firecracker_repo}
+cd firecracker
+git checkout ${firecracker_version}
+./tools/devtool --unattended build --release -- --features vsock
+
+ln -s ./build/release/firecracker ./firecracker-static


### PR DESCRIPTION
Start packaging the supported version of firecracker.

Requires: https://github.com/kata-containers/runtime/pull/1104

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>