### PR TITLE
ccloudvm: update kata install URL

### DIFF
--- a/ccloudvm/kata-docker-xenial.yaml
+++ b/ccloudvm/kata-docker-xenial.yaml
@@ -30,8 +30,9 @@ write_files:
 runcmd:
 
  - {{beginTask . "Install kata"}}
- - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/ /' >> /etc/apt/sources.list.d/kata-containers.list"
- - {{proxyVars .}} curl -sL http://download.opensuse.org/repositories/home:/katacontainers:/release/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
+ - ARCH=$(arch)
+ - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
+ - {{proxyVars .}} curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
  - sudo -E apt-get update
  - sudo -E apt-get -y install kata-runtime
  - {{endTaskCheck .}}


### PR DESCRIPTION
Update the kata install commands to point to the correct repository URL.

Fixes: #326

Signed-off-by: Marco Vedovati <mvedovati@suse.com>