### PR TITLE
kata-deploy: Check crio conf before update

### DIFF
--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -65,7 +65,10 @@ function configure_crio() {
   runtime_path = "/opt/kata/bin/kata-fc"
 EOT
 
-	sed -i 's|\(\[crio\.runtime\]\)|\1\nmanage_network_ns_lifecycle = true|' "$crio_conf_file"
+  # Replace if exists, insert otherwise
+  grep -Fq 'manage_network_ns_lifecycle =' $crio_conf_file \
+  && sed -i '/manage_network_ns_lifecycle =/c manage_network_ns_lifecycle = true' $crio_conf_file \
+  || sed -i '/\[crio.runtime\]/a manage_network_ns_lifecycle = true' $crio_conf_file
 }
 
 function configure_containerd() {


### PR DESCRIPTION
kata-deploy inserts 'manage_network_ns_lifecycle' into crio.conf without any
prior checks and if there is a previous entry in the file, this becomes a
duplicate causing crio service restart issues. This patch addresses that
particular scenario.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>