### PR TITLE
snap: add support for s390x

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -43,6 +43,10 @@ install_yq() {
 		goarch=ppc64le
 		;;
 
+	"s390x")
+		goarch=s390x
+		;;
+
 	"*")
 		echo "Arch $(arch) not supported"
 		exit

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -203,6 +203,10 @@ parts:
           config="arm64_kata_kvm_${x_version}"
         ;;
 
+        "s390x")
+          config="s390_kata_kvm_${x_version}"
+        ;;
+
         *)
           echo "ERROR: Unsupported architecture $(arch)"
           exit 1


### PR DESCRIPTION
This allows running packaging CI scripts on s390x to create snap image.
For completeness, snap-build files also created.

Fixes #341

Signed-off-by: Tuan Hoang <tmhoang@linux.vnet.ibm.com>