### PR TITLE
Release 1.5.1

### DIFF
--- a/obs-packaging/linux-container/kata-linux-container.spec-template
+++ b/obs-packaging/linux-container/kata-linux-container.spec-template
@@ -82,6 +82,12 @@ BuildKernel() {
     find kata-kernel-configs -name "${kernelArch}_kata_kvm_*" -exec cp {} .config \;
 	[ -f .config ] || (echo "ERROR: cannot find the kernel config file for the ${kernelArch} architecture"; exit 1)
 
+    %if 0%{?rhel_version}
+    # RHEL in OBS has updated gcc.
+    # https://github.com/kata-containers/packaging/pull/370#issuecomment-469620154
+    sed -i -e 's/CONFIG_RETPOLINE=y/CONFIG_RETPOLINE=n/g' .config
+    %endif
+
     %if 0%{?fedora}
     #Fedora uses gcc 8, build is failing due to warnings.
     export CFLAGS="-Wno-error=restrict"

--- a/obs-packaging/versions.txt
+++ b/obs-packaging/versions.txt
@@ -1,24 +1,24 @@
 # This is a generated file from gen_versions_txt.sh
 
-kata_version=1.5.0
+kata_version=1.5.1
 
-kata_runtime_version=1.5.0
-kata_runtime_hash=5f7fcd773089a615b776862f92217e987f06df0a
+kata_runtime_version=1.5.1
+kata_runtime_hash=47a44773d0ebd683ec853b3c920e742715ae8ce6
 
-kata_proxy_version=1.5.0
-kata_proxy_hash=9e77a0b1925d1ab3afda7d46ec256be8a9cff222
+kata_proxy_version=1.5.1
+kata_proxy_hash=9faf7764002daf970e57c6584717a3380341b2dd
 
-kata_shim_version=1.5.0
-kata_shim_hash=efbf3bb25065ce89099630b753d218cdc678e758
+kata_shim_version=1.5.1
+kata_shim_hash=2dbd643783e0a141c91e375023631816a256d9c3
 
-kata_agent_version=1.5.0
-kata_agent_hash=a581aebf47386df570f796cb835bd23820448b9b
+kata_agent_version=1.5.1
+kata_agent_hash=656036e7570ee258dcb41d5b9fefad847643898e
 
-kata_ksm_throttler_version=1.5.0
-kata_ksm_throttler_hash=3dd4c9f8b494ebd79aa0685d56891e5cdab69d2b
+kata_ksm_throttler_version=1.5.1
+kata_ksm_throttler_hash=ad51504a795b23f49b27560f9e3eaf1b41e9151c
 
 # Dependencies
-kata_osbuilder_version=1.5.0
+kata_osbuilder_version=1.5.1
 
 qemu_lite_version=2.11.0
 qemu_lite_hash=87517afd726526e6e32a3e0be07eca34b8cc6962
@@ -26,7 +26,7 @@ qemu_lite_hash=87517afd726526e6e32a3e0be07eca34b8cc6962
 qemu_vanilla_version=2.11.2
 qemu_vanilla_hash=0982a56a551556c704dc15752dabf57b4be1c640
 
-kernel_version=4.14.67
+kernel_version=4.14.102
 
 # Golang
 go_version=1.11.1

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -35,14 +35,13 @@ get_from_kata_deps() {
 	local branch="${2:-master}"
 	local runtime_repo="github.com/kata-containers/runtime"
 	GOPATH=${GOPATH:-${HOME}/go}
-	versions_file="${GOPATH}/src/github.com/kata-containers/runtime/versions.yaml"
+	versions_file="versions-${branch}.yaml"
 	if [ ! -e "${versions_file}" ]; then
 		yaml_url="https://raw.githubusercontent.com/kata-containers/runtime/${branch}/versions.yaml"
 		echo "versions file (${versions_file}) does not exist" >&2
 		echo "Download from ${yaml_url}" >&2
 		#make sure yq is installed
 		install_yq >&2
-		versions_file="versions_${branch}.yaml"
 		curl --silent -o "${versions_file}" "$yaml_url"
 	fi
 	result=$("${GOPATH}/bin/yq" read "$versions_file" "$dependency")


### PR DESCRIPTION
Fix issues found in Kata release 1.5.1

Note: The  ubuntu 16.04 failed on OBS, I confirm that golang 1.11 does not work with this ubuntu version.

https://github.com/kata-containers/packaging/issues/264
