### PR TITLE
stale: add initial configuration for stale probot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,53 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+
+closeComment: >
+This issue/pull request has been automatically closed due to inactivity and no response to the auto close bot
+request. If you feel this is inappropriate, please respond to this issue requesting it to be re-opened. 
+
+# Limit the number of actions (marking or closing issues/PRs) per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Issue specific handling:
+issues:
+  daysUntilStale: 60
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+   exemptLabels:
+     - limitation
+     - security
+     - P1
+
+# Pull request specific handling:
+pulls:
+  daysUntilStale: 30
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. See [assisted pr workflow](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md#assisted-pr-workflow)
+    if any developers would like to help pickup this pull request.  Thank you for your contributions.
+  exemptLabels:
+    - pinned
+    - security
+    - release-gating
+    - P1
+


### PR DESCRIPTION
To assist in tracking older issues/PRs, let's add a tool for marking
issues and pull requests as being stale after 60 days of inactivity. A
stale issue/PR will be closed after 7 days of being marked stale.

This is functionality, a GitHub application from probot (and hosted by in this configuration), and only has visibility into GitHub issue/PR's metadata, and ability to comment / close.  

I'd be happy with using this, and we can migrate to use GitHub actions once more widely available (beta)