### PR TITLE
snap: launchpad: Add missing kernel dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -184,6 +184,9 @@ parts:
     build-packages:
       - libelf-dev
       - curl
+      - build-essential
+      - bison
+      - flex
     build-snaps:
       - yq
     override-build: |


### PR DESCRIPTION
new kernel, new dependencies. Add bison, build-essential and flex as
kernel dependencies

fixes #395

Signed-off-by: Julio Montes <julio.montes@intel.com>