### PR TITLE
Override build user+host+timestamp

### DIFF
--- a/obs-packaging/linux-container/debian.rules
+++ b/obs-packaging/linux-container/debian.rules
@@ -18,6 +18,11 @@ override_dh_auto_build:
 	rm -f .config
 	find $(KERNEL_CONFIGS) -name "$(KERNEL_ARCH)_kata_kvm_*" -exec cp {} .config \;
 	[ -f .config ] || (@echo "ERROR: cannot find the kernel config file for the $(KERNEL_ARCH) architecture"; exit 1)
+	# https://github.com/kata-containers/packaging/issues/394 enable reproducible builds:
+	export KBUILD_BUILD_USER=katabuilduser
+	export KBUILD_BUILD_HOST=katabuildhost
+        # Default to zero seconds after midnight 1970-01-01 (the epoch)
+	export KBUILD_BUILD_TIMESTAMP="$(LANG=C date -u -d "@${SOURCE_DATE_EPOCH:-0}")"
 	make -s ARCH=$(KERNEL_ARCH) oldconfig > /dev/null
 	make -s CONFIG_DEBUG_SECTION_MISMATCH=y ARCH=$(KERNEL_ARCH)
 

--- a/obs-packaging/linux-container/kata-linux-container.spec-template
+++ b/obs-packaging/linux-container/kata-linux-container.spec-template
@@ -87,6 +87,11 @@ BuildKernel() {
     export CFLAGS="-Wno-error=restrict"
     export EXTRA_CFLAGS="-Wno-format-truncation -Wno-cast-function-type -Wno-error=restrict -Wno-error"
     %endif
+    # https://github.com/kata-containers/packaging/issues/394 enable reproducible builds:
+    export KBUILD_BUILD_USER=katabuilduser
+    export KBUILD_BUILD_HOST=katabuildhost
+    # Default to zero seconds after midnight 1970-01-01 (the epoch)
+    export KBUILD_BUILD_TIMESTAMP="$(LANG=C date -u -d "@${SOURCE_DATE_EPOCH:-0}")"
 
     make -s ARCH=$kernelArch oldconfig > /dev/null
     make -s CONFIG_DEBUG_SECTION_MISMATCH=y %{?_smp_mflags} ARCH=$kernelArch %{?sparse_mflags} || exit 1


### PR DESCRIPTION
Override build user+host+timestamp
to make kata-linux-container package builds reproducible.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of the variable.
`SOURCE_DATE_EPOCH` is unset atm in the .spec file case because no changelog is there to allow rpm to parse the date from it.

Fixes part of issue #394

This PR was done while working on reproducible builds for openSUSE.