### PR TITLE
Credit packagecloud for package hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ packages are contained within this repository.
 In addition, Kata build artifacts are available within a container image, created by a
 [Dockerfile](kata-deploy/Dockerfile).  Reference daemonsets are provided in [kata-deploy](kata-deploy),
 which make installation of Kata Containers in a running Kubernetes Cluster very straightforward.
+
+## Credits
+
+Kata Containers packaging uses [packagecloud](https://packagecloud.io) for
+package hosting.


### PR DESCRIPTION
We use a packagecloud OSS account for package hosting.
As part of the arrangement with packagecloud we need to
credit them and add a link back to https://packagecloud.io
on our website and project README.

This was added to the kata-containers repository's README,
but it is also probably appropriate to add it to the packaging
README as well.

Signed-off-by: Thierry Carrez <thierry@openstack.org>