### PR TITLE
kata-deploy: remove Trusted annotations from examples

### DIFF
--- a/kata-deploy/examples/test-deploy-kata-qemu.yaml
+++ b/kata-deploy/examples/test-deploy-kata-qemu.yaml
@@ -11,9 +11,6 @@ spec:
       run: php-apache-kata-qemu
   template:
     metadata:
-      annotations:
-        io.kubernetes.cri-o.TrustedSandbox: "false"
-        io.kubernetes.cri.untrusted-workload: "true"
       labels:
         run: php-apache-kata-qemu
     spec:


### PR DESCRIPTION
We no longer use the TrustedSandbox style annotations now we
have moved to the RuntimeClass method of choosing a runtime.
Drop the remaining Trusted items from the examples.

Fixes: #403

Signed-off-by: Graham Whaley <graham.whaley@intel.com>