### PR TITLE
kata-deploy: crio.conf: Add some whitespace and comments

### DIFF
--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -71,6 +71,8 @@ function configure_crio() {
 		sed -i "/^\[$kata_qemu_conf\]/,+1s#runtime_path.*#runtime_path = \"${kata_qemu_path}\"#" $crio_conf_file 
 	else
 		cat <<EOT | tee -a "$crio_conf_file"
+
+# Path to the Kata Containers runtime binary that uses the QEMU hypervisor.
 [$kata_qemu_conf]
   runtime_path = "${kata_qemu_path}"
 EOT
@@ -81,6 +83,8 @@ EOT
 		sed -i "/^\[$kata_fc_conf\]/,+1s#runtime_path.*#runtime_path = \"${kata_fc_path}\"#" $crio_conf_file 
 	else
 		cat <<EOT | tee -a "$crio_conf_file"
+
+# Path to the Kata Containers runtime binary that uses the firecracker hypervisor.
 [$kata_fc_conf]
   runtime_path = "${kata_fc_path}"
 EOT


### PR DESCRIPTION
When writing our runtime configs to crio.conf, let's add some
whitespace and comments to make it clearer, and fit in with the
rest of the crio.conf file.

Fixes: #412

Signed-off-by: Graham Whaley <graham.whaley@intel.com>