### PR TITLE
kata-deploy: Add runtimeclass yaml to kata-deploy

### DIFF
--- a/kata-deploy/k8s-1.13/kata-fc-runtimeClass.yaml
+++ b/kata-deploy/k8s-1.13/kata-fc-runtimeClass.yaml
@@ -1,0 +1,5 @@
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1alpha1
+metadata:
+    name: kata-fc
+handler: kata-fc

--- a/kata-deploy/k8s-1.13/kata-qemu-runtimeClass.yaml
+++ b/kata-deploy/k8s-1.13/kata-qemu-runtimeClass.yaml
@@ -1,0 +1,12 @@
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1alpha1
+metadata:
+    name: kata
+handler: kata
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1alpha1
+metadata:
+    name: kata-qemu
+handler: kata-qemu

--- a/kata-deploy/k8s-1.14/kata-fc-runtimeClass.yaml
+++ b/kata-deploy/k8s-1.14/kata-fc-runtimeClass.yaml
@@ -1,0 +1,5 @@
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1beta1
+metadata:
+    name: kata-fc
+handler: kata-fc

--- a/kata-deploy/k8s-1.14/kata-qemu-runtimeClass.yaml
+++ b/kata-deploy/k8s-1.14/kata-qemu-runtimeClass.yaml
@@ -1,0 +1,12 @@
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1beta1
+metadata:
+    name: kata
+handler: kata
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1beta1
+metadata:
+    name: kata-qemu
+handler: kata-qemu


### PR DESCRIPTION
Add the yaml for kata RuntimeClasses. It is useful to
include this explicitly, rather than just having it in the docs.
Also, this feature has transitioned from alpha to beta from k8s 1.13
to 1.14. Hence maintain separate yamls for these versions.

We should eventually move towards maintaining separate versions
for all our yaml files for the k8s versions that we support.

Fixes #444

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>