### PR TITLE
packages: Remove git hash from version

### DIFF
--- a/obs-packaging/kata-containers-image/build_image.sh
+++ b/obs-packaging/kata-containers-image/build_image.sh
@@ -20,6 +20,7 @@ export   GOPATH="${tmp_dir}/go"
 
 export GOPATH=${GOPATH:-${HOME}/go}
 source "${script_dir}/../../scripts/lib.sh"
+source "${script_dir}/../scripts/pkglib.sh"
 
 exit_handler() {
 	[ -d "${tmp_dir}" ] && sudo rm -rf "$tmp_dir"
@@ -62,7 +63,7 @@ build_image() {
 create_tarball() {
 	agent_sha=$(get_repo_hash "${GOPATH}/src/github.com/kata-containers/agent")
 	#reduce sha size for short names
-	agent_sha=${agent_sha:0:11}
+	agent_sha=${agent_sha:0:${short_commit_length}}
 	tarball_name="kata-containers-${kata_osbuilder_version}-${agent_sha}-${arch_target}.tar.gz"
 	image_name="kata-containers-image_${img_distro}_${kata_osbuilder_version}_agent_${agent_sha}.img"
 	initrd_name="kata-containers-initrd_${initrd_distro}_${kata_osbuilder_version}_agent_${agent_sha}.initrd"

--- a/obs-packaging/kata-containers-image/build_image.sh
+++ b/obs-packaging/kata-containers-image/build_image.sh
@@ -35,6 +35,10 @@ kata_version="master"
 kata_osbuilder_version="${KATA_OSBUILDER_VERSION:-}"
 # Agent version
 agent_version="${AGENT_VERSION:-}"
+if [ -z "${agent_version}" ]; then
+	source "${script_dir}/../versions.txt"
+	agent_version="${kata_agent_hash}"
+fi
 
 readonly destdir="${PWD}"
 

--- a/obs-packaging/kata-containers-image/build_image.sh
+++ b/obs-packaging/kata-containers-image/build_image.sh
@@ -32,7 +32,7 @@ arch_target="$(uname -m)"
 kata_version="master"
 
 # osbuilder info
-kata_osbuilder_version="${KATA_OSBUILDER_VERSION:-}"
+osbuider_version="${KATA_OSBUILDER_VERSION:-}"
 # Agent version
 agent_version="${AGENT_VERSION:-}"
 if [ -z "${agent_version}" ]; then
@@ -68,9 +68,9 @@ create_tarball() {
 	agent_sha=$(get_repo_hash "${GOPATH}/src/github.com/kata-containers/agent")
 	#reduce sha size for short names
 	agent_sha=${agent_sha:0:${short_commit_length}}
-	tarball_name="kata-containers-${kata_osbuilder_version}-${agent_sha}-${arch_target}.tar.gz"
-	image_name="kata-containers-image_${img_distro}_${kata_osbuilder_version}_agent_${agent_sha}.img"
-	initrd_name="kata-containers-initrd_${initrd_distro}_${kata_osbuilder_version}_agent_${agent_sha}.initrd"
+	tarball_name="kata-containers-${osbuider_version}-${agent_sha}-${arch_target}.tar.gz"
+	image_name="kata-containers-image_${img_distro}_${osbuider_version}_agent_${agent_sha}.img"
+	initrd_name="kata-containers-initrd_${initrd_distro}_${osbuider_version}_agent_${agent_sha}.initrd"
 
 	mv "${tmp_dir}/osbuilder/kata-containers.img" "${image_name}"
 	mv "${tmp_dir}/osbuilder/kata-containers-initrd.img" "${initrd_name}"
@@ -107,7 +107,7 @@ main() {
 		esac
 	done
 	# osbuilder info
-	[ -n "${kata_osbuilder_version}" ] || kata_osbuilder_version="${kata_version}"
+	[ -n "${osbuider_version}" ] || osbuider_version="${kata_version}"
 	# Agent version
 	[ -n "${agent_version}" ] || agent_version="${kata_version}"
 
@@ -126,7 +126,7 @@ main() {
 	shift "$((OPTIND - 1))"
 	git clone "$osbuilder_url" "${tmp_dir}/osbuilder"
 	pushd "${tmp_dir}/osbuilder"
-	git checkout "${kata_osbuilder_version}"
+	git checkout "${osbuider_version}"
 	build_initrd
 	build_image
 	create_tarball

--- a/obs-packaging/kata-containers-image/kata-containers-image.spec-template
+++ b/obs-packaging/kata-containers-image/kata-containers-image.spec-template
@@ -1,9 +1,6 @@
-%define version @VERSION@
-%define release @RELEASE@
-
 Name:           kata-containers-image
-Version:        %{version}
-Release:        %{release}.<B_CNT>
+Version:        @VERSION@
+Release:        @RELEASE@
 License:        Artistic-1.0 BSD-3-Clause BSD-3-Clause-Kata BSD-4-Clause-UC GFDL-1.3 GPL-2.0 GPL-2.0+ GPL-3.0 GPL-3.0+ LGPL-2.0 LGPL-2.0+ LGPL-2.1 LGPL-3.0+ MIT MPL-2.0 Public-Domain 
 Summary:        Kata Containers Image
 Url:            https://github.com/kata-containers/osbuilder

--- a/obs-packaging/kata-containers-image/update.sh
+++ b/obs-packaging/kata-containers-image/update.sh
@@ -48,7 +48,7 @@ replace_list=(
 
 verify
 rm -rf kata-containers.tar.gz
-image_tarball=$(find . -name 'kata-containers-'"${VERSION/\~/-}"'-'"${kata_agent_hash:0:11}"'-*.tar.gz')
+image_tarball=$(find . -name 'kata-containers-'"${VERSION/\~/-}"'-'"${kata_agent_hash:0:${short_commit_length}}"'-*.tar.gz')
 [ -f "${image_tarball}" ] || die "image not found"
 cp "${image_tarball}" kata-containers.tar.gz
 

--- a/obs-packaging/ksm-throttler/_service-template
+++ b/obs-packaging/ksm-throttler/_service-template
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="url">https://github.com/kata-containers/ksm-throttler.git</param>
     <param name="filename">kata-ksm-throttler</param>
-    <param name="versionformat">@VERSION@.git+@HASH@</param>
+    <param name="versionformat">@VERSION@</param>
     <param name="revision">@HASH@</param>
  </service>
  <service name="recompress">

--- a/obs-packaging/ksm-throttler/kata-ksm-throttler.dsc-template
+++ b/obs-packaging/ksm-throttler/kata-ksm-throttler.dsc-template
@@ -1,13 +1,13 @@
 Format: 3.0 (quilt)
 Source: kata-ksm-throttler
-Version: @VERSION@.git+@HASH@-@RELEASE@
+Version: @VERSION@-@RELEASE@
 Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Homepage: https://katacontainers.io
 Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, pkg-config, dh-systemd, systemd
-Debtransform-Tar: kata-ksm-throttler-@VERSION@.git+@HASH@.tar.gz
+Debtransform-Tar: kata-ksm-throttler-@VERSION@.tar.gz
 
 Package: kata-ksm-throttler
 Architecture: @deb_arch@

--- a/obs-packaging/ksm-throttler/kata-ksm-throttler.spec-template
+++ b/obs-packaging/ksm-throttler/kata-ksm-throttler.spec-template
@@ -16,8 +16,8 @@
 %define  debug_package %{nil}
 
 Name:      kata-ksm-throttler
-Version:   @VERSION@.git+@HASH@
-Release:   @RELEASE@.<B_CNT>
+Version:   @VERSION@
+Release:   @RELEASE@
 Source0:   %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Summary  : No detailed summary available

--- a/obs-packaging/linux-container/kata-linux-container.spec-template
+++ b/obs-packaging/linux-container/kata-linux-container.spec-template
@@ -6,7 +6,7 @@
 
 Name:           kata-linux-container
 Version:        @VERSION@.@CONFIG_VERSION@
-Release:        @RELEASE@.<B_CNT>
+Release:        @RELEASE@
 License:        GPL-2.0
 Summary:        The Linux kernel optimized for running inside a container
 Group:          System/Kernel

--- a/obs-packaging/proxy/_service-template
+++ b/obs-packaging/proxy/_service-template
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="url">https://github.com/kata-containers/proxy.git</param>
     <param name="filename">kata-proxy</param>
-    <param name="versionformat">@VERSION@+git.@HASH@</param>
+    <param name="versionformat">@VERSION@</param>
     <param name="revision">@HASH@</param>
  </service>
  <service name="recompress">

--- a/obs-packaging/proxy/kata-proxy.dsc-template
+++ b/obs-packaging/proxy/kata-proxy.dsc-template
@@ -1,13 +1,13 @@
 format: 3.0 (quilt)
 Source: kata-proxy
-Version: @VERSION@+git.@HASH@-@RELEASE@
+Version: @VERSION@-@RELEASE@
 Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
 Homepage: https://katacontainers.io
-Debtransform-Tar: kata-proxy-@VERSION@+git.@HASH@.tar.gz
+Debtransform-Tar: kata-proxy-@VERSION@.tar.gz
 
 Package: kata-proxy
 Architecture: @deb_arch@

--- a/obs-packaging/proxy/kata-proxy.spec-template
+++ b/obs-packaging/proxy/kata-proxy.spec-template
@@ -10,8 +10,8 @@
 
 %undefine _missing_build_ids_terminate_build
 Name:      kata-proxy
-Version:   @VERSION@+git.@HASH@
-Release:   @RELEASE@.<B_CNT>
+Version:   @VERSION@
+Release:   @RELEASE@
 Source0:   %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: pkgconfig(systemd)

--- a/obs-packaging/qemu-lite/qemu-lite.spec-template
+++ b/obs-packaging/qemu-lite/qemu-lite.spec-template
@@ -1,7 +1,7 @@
 %global qemu_lite_hash @QEMU_LITE_HASH@
 Name: qemu-lite
 Version: @VERSION@+git.%{qemu_lite_hash}
-Release: @RELEASE@.<B_CNT>
+Release: @RELEASE@
 Source0: %{name}-%{version}.tar.gz
 Source1: qemu-lite-rpmlintrc
 Source2: configure-hypervisor.sh

--- a/obs-packaging/qemu-lite/update.sh
+++ b/obs-packaging/qemu-lite/update.sh
@@ -38,7 +38,7 @@ set_versions "${qemu_lite_hash}"
 replace_list=(
 	"VERSION=$VERSION"
 	"RELEASE=$RELEASE"
-	"QEMU_LITE_HASH=${qemu_lite_hash:0:10}"
+	"QEMU_LITE_HASH=${qemu_lite_hash:0:${short_commit_length}}"
 )
 verify
 echo "Verify succeed."

--- a/obs-packaging/qemu-vanilla/qemu-vanilla.spec-template
+++ b/obs-packaging/qemu-vanilla/qemu-vanilla.spec-template
@@ -1,7 +1,7 @@
 %global qemu_vanilla_hash @QEMU_VANILLA_HASH@
 Name: qemu-vanilla
 Version: @VERSION@+git.%{qemu_vanilla_hash}
-Release: @RELEASE@.<B_CNT>
+Release: @RELEASE@
 Source0: %{name}-%{version}.tar.gz
 Source1: qemu-vanilla-rpmlintrc
 Source2: configure-hypervisor.sh

--- a/obs-packaging/qemu-vanilla/update.sh
+++ b/obs-packaging/qemu-vanilla/update.sh
@@ -39,7 +39,7 @@ set_versions "${qemu_vanilla_hash}"
 replace_list=(
 	"VERSION=$VERSION"
 	"RELEASE=$RELEASE"
-	"QEMU_VANILLA_HASH=${qemu_vanilla_hash:0:10}"
+	"QEMU_VANILLA_HASH=${qemu_vanilla_hash:0:${short_commit_length}}"
 )
 
 verify

--- a/obs-packaging/runtime/_service-template
+++ b/obs-packaging/runtime/_service-template
@@ -6,7 +6,7 @@
     <param name="url">https://github.com/kata-containers/runtime.git</param>
     <param name="filename">kata-runtime</param>
     <!--- versionformat defines the name of the  tarball. -->
-    <param name="versionformat">@VERSION@+git.@HASH@</param>
+    <param name="versionformat">@VERSION@</param>
     <param name="revision">@HASH@</param>
  </service>
  <service name="recompress">

--- a/obs-packaging/runtime/kata-runtime.dsc-template
+++ b/obs-packaging/runtime/kata-runtime.dsc-template
@@ -2,14 +2,14 @@ Format: 3.0 (quilt)
 Source: kata-runtime
 # Version is expected to be started with a digit following by an alphanumeric string
 # e.g. 1.0.0+git.1234567-1
-Version: @VERSION@+git.@HASH@-@RELEASE@
+Version: @VERSION@-@RELEASE@
 Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
 Homepage: https://katacontainers.io
-Debtransform-Tar: kata-runtime-@VERSION@+git.@HASH@.tar.gz
+Debtransform-Tar: kata-runtime-@VERSION@.tar.gz
 
 Package: kata-runtime
 Architecture: @deb_arch@

--- a/obs-packaging/runtime/kata-runtime.dsc-template
+++ b/obs-packaging/runtime/kata-runtime.dsc-template
@@ -13,9 +13,9 @@ Debtransform-Tar: kata-runtime-@VERSION@+git.@HASH@.tar.gz
 
 Package: kata-runtime
 Architecture: @deb_arch@
-Depends: kata-containers-image (>= @kata_osbuilder_version@), kata-linux-container (>= @linux_container_version@),
-         kata-proxy (>= @kata_proxy_version@), kata-shim (>= @kata_shim_version@),
-	 kata-ksm-throttler(>= @ksm_throttler_version@), qemu-lite(>= @qemu_lite_version@) [amd64],
-	 qemu-vanilla(>= @qemu_vanilla_version@)
+Depends: kata-containers-image (= @kata_osbuilder_version@), kata-linux-container (= @linux_container_version@),
+         kata-proxy (= @kata_proxy_version@), kata-shim (= @kata_shim_version@),
+	 kata-ksm-throttler(= @ksm_throttler_version@), qemu-lite(= @qemu_lite_version@) [amd64],
+	 qemu-vanilla(= @qemu_vanilla_version@)
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Kata Containers hypervisor, rather than a standard Linux container.

--- a/obs-packaging/runtime/kata-runtime.spec-template
+++ b/obs-packaging/runtime/kata-runtime.spec-template
@@ -1,5 +1,3 @@
-%global PREFIX /usr/
-%global BINDIR %{PREFIX}/bin
 %global DOMAIN github.com
 %global ORG kata-containers
 %global PROJECT runtime

--- a/obs-packaging/runtime/kata-runtime.spec-template
+++ b/obs-packaging/runtime/kata-runtime.spec-template
@@ -24,16 +24,16 @@ License  : Apache-2.0
 
 BuildRequires: git
 
-%{!?el7 || !?suse_version:Requires: qemu-lite >= @qemu_lite_obs_fedora_version@ }
+%{!?el7 || !?suse_version:Requires: qemu-lite = @qemu_lite_obs_fedora_version@ }
 
-Requires: kata-containers-image >= @kata_osbuilder_version@
-Requires: kata-linux-container >= @linux_container_version@
-Requires: kata-proxy >= @kata_proxy_version@
-Requires: kata-shim >= @kata_shim_version@
-Requires: kata-ksm-throttler >= @ksm_throttler_version@
-Requires: qemu-vanilla >= @qemu_vanilla_version@
+Requires: kata-containers-image = @kata_osbuilder_version@
+Requires: kata-linux-container = @linux_container_version@
+Requires: kata-proxy = @kata_proxy_version@
+Requires: kata-shim = @kata_shim_version@
+Requires: kata-ksm-throttler = @ksm_throttler_version@
+Requires: qemu-vanilla = @qemu_vanilla_version@
 %ifarch x86_64
-Requires: qemu-lite >= @qemu_lite_version@
+Requires: qemu-lite = @qemu_lite_version@
 %endif
 
 # Patches

--- a/obs-packaging/runtime/kata-runtime.spec-template
+++ b/obs-packaging/runtime/kata-runtime.spec-template
@@ -14,8 +14,8 @@
 Name:      kata-runtime
 # Version is expected to be started with a digit following by an alphanumeric string
 # e.g. 1.0.0+git.1234567
-Version:   @VERSION@+git.@HASH@
-Release:   @RELEASE@.<B_CNT>
+Version:   @VERSION@
+Release:   @RELEASE@
 Source0:   %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Summary  : No detailed summary available

--- a/obs-packaging/runtime/update.sh
+++ b/obs-packaging/runtime/update.sh
@@ -45,33 +45,26 @@ cli "$@"
 
 # Package depedencies
 info "requires:"
-PROXY_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/proxy")
-PROXY_REQUIRED_VERESION=$(pkg_version "${kata_proxy_version}" "${PROXY_RELEASE}" "${kata_proxy_hash}")
+PROXY_REQUIRED_VERESION=$(pkg_version "${kata_proxy_version}" "" "")
 info "proxy ${PROXY_REQUIRED_VERESION}"
 
-SHIM_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/shim")
-SHIM_REQUIRED_VERSION=$(pkg_version "${kata_shim_version}" "${SHIM_RELEASE}" "${kata_shim_hash}")
+SHIM_REQUIRED_VERSION=$(pkg_version "${kata_shim_version}" "" "")
 info "shim ${SHIM_REQUIRED_VERSION}"
 
-KERNEL_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/linux-container")
 KERNEL_CONFIG_VERSION=$(cat "${SCRIPT_DIR}/../../kernel/kata_config_version")
-KERNEL_REQUIRED_VERSION=$(pkg_version "${kernel_version}.${KERNEL_CONFIG_VERSION}" "${KERNEL_RELEASE}" "")
+KERNEL_REQUIRED_VERSION=$(pkg_version "${kernel_version}.${KERNEL_CONFIG_VERSION}" "" "")
 info "kata-linux-container ${KERNEL_REQUIRED_VERSION}"
 
-KSM_THROTTLER_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/ksm-throttler")
-KSM_THROTTLER_REQUIRED_VERSION=$(pkg_version "${kata_ksm_throttler_version}" "${KSM_THROTTLER_RELEASE}" "${kata_ksm_throttler_hash}")
+KSM_THROTTLER_REQUIRED_VERSION=$(pkg_version "${kata_ksm_throttler_version}" "" "")
 info "ksm-throttler ${KSM_THROTTLER_REQUIRED_VERSION}"
 
-KATA_CONTAINERS_IMAGE_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/kata-containers-image")
-KATA_IMAGE_REQUIRED_VERSION=$(pkg_version "${kata_osbuilder_version}" "${KATA_CONTAINERS_IMAGE_RELEASE}" "")
+KATA_IMAGE_REQUIRED_VERSION=$(pkg_version "${kata_osbuilder_version}" "" "")
 info "image ${KATA_IMAGE_REQUIRED_VERSION}"
 
-KATA_CONTAINERS_QEMU_LITE_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/qemu-lite")
-KATA_QEMU_LITE_REQUIRED_VERSION=$(pkg_version "${qemu_lite_version}" "${KATA_CONTAINERS_QEMU_LITE_RELEASE}" "${qemu_lite_hash}")
+KATA_QEMU_LITE_REQUIRED_VERSION=$(pkg_version "${qemu_lite_version}" "" "${qemu_lite_hash}")
 info "qemu-lite ${KATA_QEMU_LITE_REQUIRED_VERSION}"
 
-KATA_CONTAINERS_QEMU_VANILLA_RELEASE=$(get_obs_pkg_release "home:${OBS_PROJECT}:${OBS_SUBPROJECT}/qemu-vanilla")
-KATA_QEMU_VANILLA_REQUIRED_VERSION=$(pkg_version "${qemu_vanilla_version}" "${KATA_CONTAINERS_QEMU_VANILLA_RELEASE}" "${qemu_vanilla_hash}")
+KATA_QEMU_VANILLA_REQUIRED_VERSION=$(pkg_version "${qemu_vanilla_version}" "" "${qemu_vanilla_hash}")
 info "qemu-vanilla ${KATA_QEMU_VANILLA_REQUIRED_VERSION}"
 
 PROJECT_REPO=${PROJECT_REPO:-home:${OBS_PROJECT}:${OBS_SUBPROJECT}/runtime}

--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -26,7 +26,7 @@ VERBOSE=false
 # package was compiled for.
 DEB_ARCH="$(go env GOARCH)"
 
-short_commit_length=7
+short_commit_length=10
 
 if command -v go; then
 	export GO_ARCH=$(go env GOARCH)

--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -291,14 +291,16 @@ function pkg_version() {
 	local pkg_release="$2"
 	local commit_id="$3"
 	[ -n "${project_version}" ] || die "${FUNCNAME}: need version"
-	[ -n "${pkg_release}" ] || die "${FUNCNAME}: pkg release is needed"
 
 	pkg_version="${project_version}"
 
 	if [ -n "$commit_id" ]; then
 		pkg_version+="+git.${commit_id:0:7}"
 	fi
-	echo "$pkg_version-${pkg_release}"
+	if [ -n "$pkg_release" ]; then
+		pkg_version+="-${pkg_release}"
+	fi
+	echo "$pkg_version"
 }
 
 function get_obs_pkg_release() {

--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -26,6 +26,8 @@ VERBOSE=false
 # package was compiled for.
 DEB_ARCH="$(go env GOARCH)"
 
+short_commit_length=7
+
 if command -v go; then
 	export GO_ARCH=$(go env GOARCH)
 else
@@ -295,7 +297,7 @@ function pkg_version() {
 	pkg_version="${project_version}"
 
 	if [ -n "$commit_id" ]; then
-		pkg_version+="+git.${commit_id:0:7}"
+		pkg_version+="+git.${commit_id:0:${short_commit_length}}"
 	fi
 	if [ -n "$pkg_release" ]; then
 		pkg_version+="-${pkg_release}"

--- a/obs-packaging/shim/_service-template
+++ b/obs-packaging/shim/_service-template
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="url">https://github.com/kata-containers/shim.git</param>
     <param name="filename">kata-shim</param>
-    <param name="versionformat">@VERSION@+git.@HASH@</param>
+    <param name="versionformat">@VERSION@</param>
     <param name="revision">@HASH@</param>
  </service>
  <service name="recompress">

--- a/obs-packaging/shim/kata-shim.dsc-template
+++ b/obs-packaging/shim/kata-shim.dsc-template
@@ -1,13 +1,13 @@
 Format: 3.0 (quilt)
 Source: kata-shim
-Version: @VERSION@+git.@HASH@-@RELEASE@
+Version: @VERSION@-@RELEASE@
 Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Build-Depends: debhelper (>= 9), git, ca-certificates, execstack, devscripts, dh-make
 Homepage: https://katacontainers.io
-Debtransform-Tar: kata-shim-@VERSION@+git.@HASH@.tar.gz
+Debtransform-Tar: kata-shim-@VERSION@.tar.gz
 
 Package: kata-shim
 Architecture: @deb_arch@

--- a/obs-packaging/shim/kata-shim.spec-template
+++ b/obs-packaging/shim/kata-shim.spec-template
@@ -8,8 +8,8 @@
 
 %undefine _missing_build_ids_terminate_build
 Name:      kata-shim
-Version:   @VERSION@+git.@HASH@
-Release:   @RELEASE@.<B_CNT>
+Version:   @VERSION@
+Release:   @RELEASE@
 Summary  : No detailed summary available
 Group    : Development/Tools
 License  : Apache-2.0


### PR DESCRIPTION
Do not add  the `commit id` to the package version, this help to install an specific kata version when
using repositories that provide different  versions like packageclould.


- Define runtime deps with the exact set of versions
of a release.

- remove obs release counter,  we already use our counter for rpms and debs and dnf  gets confused
if we used. 

Fixes: #453

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>