### PR TITLE
scripts: support Qemu 4

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -304,7 +304,7 @@ generate_qemu_options() {
 	# implicitly enabled in Fedora 27).
 	qemu_options+=(size:--disable-linux-aio)
 
-	if [ "${qemu_version_major}" -ge 3 ] && [ "${qemu_version_minor}" -ge 1 ]; then
+	if [[ "${qemu_version_major}" -ge 4 || ( "${qemu_version_major}" -ge 3  &&  "${qemu_version_minor}" -ge 1 ) ]]; then
 		# Disable libpmem, vNVDIMM backend (aka rootfs image) shouldn't be modifed
 		# by the guest
 		qemu_options+=(security:--disable-libpmem)
@@ -362,8 +362,9 @@ generate_qemu_options() {
 	qemu_options+=(functionality:--enable-cap-ng)
 
 	# AVX2 is enabled by default, make sure it's on
-	if [ "${qemu_version_major}" -ge 3 ] && [ "${qemu_version_minor}" -ge 1 ]; then
+	if [[ "${qemu_version_major}" -ge 4 || ( "${qemu_version_major}" -ge 3  &&  "${qemu_version_minor}" -ge 1 ) ]]; then
 		qemu_options+=(speed:--enable-avx2)
+		qemu_options+=(speed:--enable-malloc-trim)
 	fi
 
 	#---------------------------------------------------------------------


### PR DESCRIPTION
modify configure-hypervisor.sh to support Qemu 4 and enable `malloc-trim`
for memory optimization.

fixes #459

Signed-off-by: Julio Montes <julio.montes@intel.com>