### PR TITLE
snap: Container fails to start on ppc64le

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,15 +47,20 @@ parts:
       cd ${pkg_gopath}
 
       # build and install
+      arch=$(uname -m)
+      if [ ${arch} == "ppc64le" ]; then
+        arch="ppc64"
+      fi
+
       make \
         PREFIX=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr \
         SKIP_GO_VERSION_CHECK=1 \
-        QEMUCMD=qemu-system-$(uname -m)
+        QEMUCMD=qemu-system-$arch
       make install \
         PREFIX=/usr \
         DESTDIR=${SNAPCRAFT_PART_INSTALL} \
         SKIP_GO_VERSION_CHECK=1 \
-        QEMUCMD=qemu-system-$(uname -m)
+        QEMUCMD=qemu-system-$arch
 
       # A snap is read-only squashfs, unfourtunately it's not possible to use the rootfs image with DAX
       # since rw access is required therefore initrd image must be used instead.


### PR DESCRIPTION
On ppc64le, qemu installed inside a snap image
is qemu-system-ppc64, but referred in config.toml
as qemu-system-ppc64le.

Fixes #467

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com