### PR TITLE
snapcraft: Consider debian ppc64el convention

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
 
       # build and install
       arch=$(uname -m)
-      if [ ${arch} == "ppc64le" ]; then
+      if [ ${arch} = "ppc64le" ]; then
         arch="ppc64"
       fi
 


### PR DESCRIPTION
Debian convention is to call it endian little rather than little endian, 
hence ppc64el rather than ppc64le. So if build system is debian,
then snap image built on it will fail to set the correct qemu binary
name.

Fixes: #473

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com