### PR TITLE
Allow kata-deploy containers to restart gracefully

### DIFF
--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -211,7 +211,7 @@ function main() {
 
 			install_artifacts
 			configure_cri_runtime $runtime
-			kubectl label node $NODE_NAME katacontainers.io/kata-runtime=true
+			kubectl label node $NODE_NAME --overwrite katacontainers.io/kata-runtime=true
 			;;
 		cleanup)
 			cleanup_cri_runtime $runtime


### PR DESCRIPTION
If the containers deployed by kata-deploy.yaml have had to restart, lack of overwrite here causes a benign error message to appear since the nodes already have `katacontainers.io/kata-runtime=true` label. Having a overwrite here means that we don't get the following error message in the logs and prevent the deployment to fail needlessly:

    error: 'katacontainers.io/kata-runtime' already has a value (true), and --overwrite is false