### PR TITLE
release:  fixes for 1.5.5

### DIFF
--- a/obs-packaging/download_image.sh
+++ b/obs-packaging/download_image.sh
@@ -8,6 +8,9 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+script_dir=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+source "${script_dir}/scripts/obs-docker.sh"
+
 handle_error() {
 	local exit_code="${?}"
 	local line_number="${1:-}"
@@ -43,7 +46,7 @@ commit=$(echo "$tag_info" | awk '{print $1}')
 echo "$commit"
 
 agent_repository="github.com/kata-containers/agent"
-tarball_name="kata-containers-${version}-${commit:0:11}-$(uname -m).tar.gz"
+tarball_name="kata-containers-${version}-${commit:0:${short_commit_length}}-$(uname -m).tar.gz"
 image_url="https://${agent_repository}/releases/download/${version}/${tarball_name}"
 curl -OL "${image_url}"
 tar xvf "${tarball_name}"

--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -3,7 +3,8 @@
 # This is a helper library for the setup scripts of each package
 # in this repository.
 
-source_dir_pkg_lib=$(dirname "${BASH_SOURCE[ ${#BASH_SOURCE[@]} - 1 ]}")
+source_dir_pkg_lib=$(dirname "${BASH_SOURCE[0]}")
+source_dir_pkg_lib=$(realpath "${source_dir_pkg_lib}")
 source "${source_dir_pkg_lib}/../../scripts/lib.sh"
 source "${source_dir_pkg_lib}/../versions.txt"
 

--- a/release/publish-kata-image.sh
+++ b/release/publish-kata-image.sh
@@ -18,6 +18,7 @@ readonly project="kata-containers"
 GOPATH=${GOPATH:-${HOME}/go}
 
 source "${script_dir}/../scripts/lib.sh"
+source "${script_dir}/../obs-packaging/scripts/pkglib.sh"
 
 die() {
 	msg="$*"
@@ -59,8 +60,7 @@ main() {
 	[ -n "${kata_version}" ] || usage "1"
 
 	agent_sha=$(get_kata_hash_from_tag "agent" "${kata_version}")
-	# tarball only has 11 chars from agent sha
-	agent_sha=${agent_sha:0:11}
+	agent_sha=${agent_sha:0:${short_commit_length}}
 	image_tarball=$(find -name 'kata-containers-*.tar.gz' | grep "${kata_version}" | grep "${agent_sha}") ||
 		"${script_dir}/../obs-packaging/kata-containers-image/build_image.sh" -v "${kata_version}"
 	image_tarball=$(find -name 'kata-containers-*.tar.gz' | grep "${kata_version}" | grep "${agent_sha}" ) || die "file not found ${image_tarball}"

--- a/release/release.md
+++ b/release/release.md
@@ -81,6 +81,8 @@ $ git pull
  
 3. Create the Kata Containers image and upload it to GitHub:
    ```bash
+   $ cd ${GOPATH}/src/github.com/kata-containers/packaging/obs-packaging
+   $ ./gen_versions_txt.sh ${BRANCH}
    $ cd ${GOPATH}/src/github.com/kata-containers/packaging/release
    $ ./publish-kata-image.sh -p ${NEW_VERSION}
    ```

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,5 +1,5 @@
 export GOPATH=${GOPATH:-${HOME}/go}
-readonly kata_arch_sh="${GOPATH}/src/github.com/kata-containers/tests/.ci/kata-arch.sh"
+kata_arch_sh="${GOPATH}/src/github.com/kata-containers/tests/.ci/kata-arch.sh"
 hub_bin="hub-bin"
 
 get_kata_arch() {


### PR DESCRIPTION
lib.sh: dont use readonly on sourced files.
   release: publish: image: fix commit length
   pkglib: fix sourced path
   docs: release: add step to generate version file before image.
   lib.sh: dont do readonly on sourced files.
   release: publish: image: fix commit length
   pkglib: fix sourced path
   docs: release: add step to generate version file before image.