### PR TITLE
kata-deploy: All binaries installed by kata should be writable by root

### DIFF
--- a/kata-deploy/Dockerfile
+++ b/kata-deploy/Dockerfile
@@ -11,6 +11,7 @@ yum install -y bzip2 jq && \
 curl -sOL ${KATA_URL}/${KATA_FILE} && \
 mkdir -p /opt/kata-artifacts && \
 tar xvf ${KATA_FILE} -C /opt/kata-artifacts/ && \
+chown -R root:root /opt/kata-artifacts/ && \
 rm ${KATA_FILE}
 
 RUN \


### PR DESCRIPTION
Prior to this, some of the binaries installed by kata were not owned by
root. Any user can write/replace these binaries.
This was happening as tar perserves ownership while creating the
archive.
Change the ownership of all binaries to root.

Fixes #489

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>