### PR TITLE
docs: release-notes: Fix markdown link

### DIFF
--- a/release/runtime-release-notes.sh
+++ b/release/runtime-release-notes.sh
@@ -132,7 +132,7 @@ See the kernel suggested [Guest Kernel config][kernel-config]
 
 ## Installation
 
-Follow the Kata [installation instructions](installation):
+Follow the Kata [installation instructions][installation].
 
 ## Issues & limitations
 


### PR DESCRIPTION
Fix markdown link to point to the rigth documentation.

Fixes: #1516