### PR TITLE
bump-repos: Make associated files adapt to newer bump script

### DIFF
--- a/Jenkinsfiles/release_pieline/bump.sh
+++ b/Jenkinsfiles/release_pieline/bump.sh
@@ -72,12 +72,7 @@ bump_kata() {
 	[ -d "${packaging_repo_dir}" ] || git clone "https://${packaging_repo}.git" "${packaging_repo_dir}"
 
 	cd "${packaging_repo_dir}/release"
-	[ "$branch" == "master" ] && ./update-repository-version.sh -p ksm-throttler "$new_version" "$branch"
-	./update-repository-version.sh -p proxy "$new_version" "$branch"
-	./update-repository-version.sh -p shim "$new_version" "$branch"
-	./update-repository-version.sh -p runtime "$new_version" "$branch"
-	[ "$branch" == "master" ] && ./update-repository-version.sh -p osbuilder "$new_version" "$branch"
-	./update-repository-version.sh -p agent "$new_version" "$branch"
+	./update-repository-version.sh -p "$new_version" "$branch"
 }
 
 setup() {

--- a/release/Makefile
+++ b/release/Makefile
@@ -9,22 +9,18 @@ MK_DIR :=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 .PHONY: bump-kata-version
 
 NEW_VERSION :=
+TARGET_BRANCH ?= "master"
 
 # Run update-repository-version.sh
 # $1 : repository to bump
 define BUMP_REPO
 	@echo "Create PR for $1 version $(NEW_VERSION)"
-	@$(MK_DIR)/update-repository-version.sh -p $1 $(NEW_VERSION)
+	@$(MK_DIR)/update-repository-version.sh -p $(NEW_VERSION) $(TARGET_BRANCH)
 endef
 
 bump-kata-version: $(REPOS)
-ifeq ($(NEW_VERSION),)
-	$(error NEW_VERSION variable is empty, provide a version)
+ifeq ($(and $(NEW_VERSION),$(TARGET_BRANCH)),)
+	$(error Either NEW_VERSION or TARGET_BRANCH variable is empty, provide both)
 else
-	$(call BUMP_REPO,agent)
-	$(call BUMP_REPO,ksm-throttler)
-	$(call BUMP_REPO,osbuilder)
-	$(call BUMP_REPO,proxy)
-	$(call BUMP_REPO,runtime)
-	$(call BUMP_REPO,shim)
+	$(call BUMP_REPO)
 endif


### PR DESCRIPTION
update-repository-version script no longer expects the repository name,
but just the version and the target branch. Modify associated Makefile
and jenkins pipeline files to adapt to that change.

Fixes: #443
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>