### PR TITLE
runtime: specify strict dependencies Debian package

### DIFF
--- a/obs-packaging/runtime/debian.control-template
+++ b/obs-packaging/runtime/debian.control-template
@@ -4,13 +4,18 @@ Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Homepage: https://katacontainers.io
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
+Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper,
+               build-essential, dh-autoreconf, make
 
 Package: kata-runtime
 Architecture: @deb_arch@
-Depends: kata-containers-image (= @kata_osbuilder_version@), kata-linux-container (= @linux_container_version@),
-         kata-proxy (= @kata_proxy_version@), kata-shim (= @kata_shim_version@),
-	 kata-ksm-throttler(= @ksm_throttler_version@), qemu-lite(= @qemu_lite_version@) [amd64],
-	 qemu-vanilla(= @qemu_vanilla_version@)
+Depends: kata-containers-image (= @kata_osbuilder_version@),
+         kata-linux-container (= @linux_container_version@),
+         kata-proxy (= @kata_proxy_version@),
+         kata-shim (= @kata_shim_version@),
+         kata-ksm-throttler(= @ksm_throttler_version@),
+         qemu-lite(= @qemu_lite_version@) [amd64],
+         qemu-vanilla(= @qemu_vanilla_version@)
 Description:
- An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Kata Containers hypervisor, rather than a standard Linux container.
+ An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x
+ secured Kata Containers hypervisor, rather than a standard Linux container.

--- a/obs-packaging/runtime/debian.control-template
+++ b/obs-packaging/runtime/debian.control-template
@@ -8,9 +8,9 @@ Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, 
 
 Package: kata-runtime
 Architecture: @deb_arch@
-Depends: kata-containers-image (>= @kata_osbuilder_version@), kata-linux-container (>= @linux_container_version@),
-         kata-proxy (>= @kata_proxy_version@), kata-shim (>= @kata_shim_version@),
-	 kata-ksm-throttler(>= @ksm_throttler_version@), qemu-lite(>= @qemu_lite_version@) [amd64],
-	 qemu-vanilla(>= @qemu_vanilla_version@)
+Depends: kata-containers-image (= @kata_osbuilder_version@), kata-linux-container (= @linux_container_version@),
+         kata-proxy (= @kata_proxy_version@), kata-shim (= @kata_shim_version@),
+	 kata-ksm-throttler(= @ksm_throttler_version@), qemu-lite(= @qemu_lite_version@) [amd64],
+	 qemu-vanilla(= @qemu_vanilla_version@)
 Description:
  An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Kata Containers hypervisor, rather than a standard Linux container.

--- a/obs-packaging/runtime/kata-runtime.dsc-template
+++ b/obs-packaging/runtime/kata-runtime.dsc-template
@@ -7,15 +7,20 @@ Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
+Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper,
+               build-essential, dh-autoreconf, make
 Homepage: https://katacontainers.io
 Debtransform-Tar: kata-runtime-@VERSION@.tar.gz
 
 Package: kata-runtime
 Architecture: @deb_arch@
-Depends: kata-containers-image (= @kata_osbuilder_version@), kata-linux-container (= @linux_container_version@),
-         kata-proxy (= @kata_proxy_version@), kata-shim (= @kata_shim_version@),
-	 kata-ksm-throttler(= @ksm_throttler_version@), qemu-lite(= @qemu_lite_version@) [amd64],
-	 qemu-vanilla(= @qemu_vanilla_version@)
+Depends: kata-containers-image (= @kata_osbuilder_version@),
+         kata-linux-container (= @linux_container_version@),
+         kata-proxy (= @kata_proxy_version@),
+         kata-shim (= @kata_shim_version@),
+         kata-ksm-throttler(= @ksm_throttler_version@),
+         qemu-lite(= @qemu_lite_version@) [amd64],
+         qemu-vanilla(= @qemu_vanilla_version@)
 Description:
- An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x secured Kata Containers hypervisor, rather than a standard Linux container.
+ An Open Containers Initiative (OCI) "runtime" that launches an Intel VT-x
+ secured Kata Containers hypervisor, rather than a standard Linux container.


### PR DESCRIPTION
Strict dependencies guarantees that an older version of the runtime will
not be installed together with a more recent version of the other kata
packages.
This complements commit e73473f.
    
Fixes: #508