### PR TITLE
build_image: Install yq before get_from_kata_deps

### DIFF
--- a/obs-packaging/kata-containers-image/build_image.sh
+++ b/obs-packaging/kata-containers-image/build_image.sh
@@ -111,6 +111,8 @@ main() {
 	# Agent version
 	[ -n "${agent_version}" ] || agent_version="${kata_version}"
 
+	install_yq
+
 	#image information
 	img_distro=$(get_from_kata_deps "assets.image.architecture.${arch_target}.name" "${kata_version}")
 	#In old branches this is not defined, use a default


### PR DESCRIPTION
build_from_docker.sh fails to read from versions.yaml as 
yq is not installed.

Fixes: #514

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com