### PR TITLE
release: Allow re-tries of tagging and github releases

### DIFF
--- a/release/tag_repos.sh
+++ b/release/tag_repos.sh
@@ -145,7 +145,7 @@ create_github_release() {
 	tag=${2:-}
 	[ -d "${repo_dir}" ] || die "No repository directory"
 	[ -n "${tag}" ] || die "No tag specified"
-	if ! "${hub_bin}" release | grep -q "^${tag}$"; then
+	if ! "${hub_bin}" release show "${tag}"; then
 		info "Creating Github release"
 		if [[ "$tag" =~ "-rc" ]]; then
 			rc_args="-p"


### PR DESCRIPTION
If anyone repository fails to upload to github a new release, this
script cannot be re-run as is today. It would nice for the script to
check if github has been updated with a release already and proceed with
the rest of the repositories if that is true.

Fixes: #519
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>