### PR TITLE
nemu: build nemu for CI

### DIFF
--- a/static-build/nemu/Dockerfile
+++ b/static-build/nemu/Dockerfile
@@ -9,6 +9,7 @@ ARG NEMU_VERSION
 ARG NEMU_OVMF
 ARG VIRTIOFSD_RELEASE
 ARG VIRTIOFSD
+ARG PREFIX
 
 WORKDIR /root/nemu
 RUN apt-get update
@@ -40,20 +41,20 @@ RUN apt-get install -y \
 	    zlib1g-dev
 
 RUN cd  .. && git clone --depth=1 "${NEMU_REPO}" nemu
-RUN git checkout "${NEMU_VERSION}"
+RUN git fetch origin --tags && git checkout "${NEMU_VERSION}"
 RUN git clone https://github.com/qemu/capstone.git capstone
 RUN git clone https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
 
 ADD configure-hypervisor.sh /root/configure-hypervisor.sh
 
-RUN PREFIX=/opt/kata /root/configure-hypervisor.sh -s kata-nemu | xargs ./configure \
+RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-nemu | xargs ./configure \
        --with-pkgversion=kata-static
 
 RUN make -j$(nproc)
 RUN make install DESTDIR=/tmp/nemu-static
 
-RUN wget "${NEMU_OVMF}" && mv OVMF.fd /tmp/nemu-static/opt/kata/share/kata-nemu/
-RUN mv /tmp/nemu-static/opt/kata/bin/qemu-system-x86_64 /tmp/nemu-static/opt/kata/bin/nemu-system-x86_64
-RUN wget "${VIRTIOFSD_RELEASE}/${VIRTIOFSD}" && chmod +x ${VIRTIOFSD} && mv ${VIRTIOFSD} /tmp/nemu-static/opt/kata/bin/
+RUN wget "${NEMU_OVMF}" && mv OVMF.fd /tmp/nemu-static/"${PREFIX}"/share/kata-nemu/
+RUN mv /tmp/nemu-static/"${PREFIX}"/bin/qemu-system-x86_64 /tmp/nemu-static/"${PREFIX}"/bin/nemu-system-x86_64
+RUN wget "${VIRTIOFSD_RELEASE}/${VIRTIOFSD}" && chmod +x ${VIRTIOFSD} && mv ${VIRTIOFSD} /tmp/nemu-static/"${PREFIX}"/bin/
 
 RUN cd /tmp/nemu-static && tar -czvf kata-nemu-static.tar.gz *

--- a/static-build/nemu/build-static-nemu.sh
+++ b/static-build/nemu/build-static-nemu.sh
@@ -46,6 +46,7 @@ info "Build ${nemu_repo} version: ${nemu_version}"
 
 http_proxy="${http_proxy:-}"
 https_proxy="${https_proxy:-}"
+prefix="${prefix:-"/opt/kata"}"
 
 docker build \
 	--build-arg http_proxy="${http_proxy}" \
@@ -55,6 +56,7 @@ docker build \
 	--build-arg NEMU_OVMF="${nemu_ovmf_release}" \
 	--build-arg VIRTIOFSD_RELEASE="${nemu_virtiofsd_release}" \
 	--build-arg VIRTIOFSD="${nemu_virtiofsd_binary}" \
+	--build-arg PREFIX="${prefix}" \
 	"${config_dir}" \
 	-f "${script_dir}/Dockerfile" \
 	-t nemu-static


### PR DESCRIPTION
NEMU needs to be built statically as the current default release will
not work for all distros. Given we are doing that, it would be nice to
test it in our CI also the same way. This change is to aid with that.

Fixes: #521
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>