### PR TITLE
obs: build: enable fedora 30

### DIFF
--- a/obs-packaging/distros
+++ b/obs-packaging/distros
@@ -8,6 +8,7 @@ CentOS_7::CentOS:CentOS-7::standard
 Debian_9::Debian:9.0::standard
 Fedora_28::Fedora:28::standard
 Fedora_29::Fedora:29::standard
+Fedora_30::Fedora:30::standard
 RHEL_7::RedHat:RHEL-7::standard
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 openSUSE_Leap_42.3::openSUSE:Leap:42.3::standard


### PR DESCRIPTION
Add fedora 30 to the list of packages to build.

Fixes: #523