### PR TITLE
ci: always use the versions from the local repository for CI

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -36,12 +36,18 @@ get_from_kata_deps() {
 	local branch="${2:-${BRANCH}}"
 	local runtime_repo="github.com/kata-containers/runtime"
 	GOPATH=${GOPATH:-${HOME}/go}
-	# We will not query the local versions.yaml file here to allow releases to
-	# always get the version from the committed tree. For our CI,
-	# .ci/install_kata_kernel.sh file in tests repository will pass the kernel
-	# version as an override to this function to allow testing of kernels before
-	# they land in tree.
-	versions_file="versions-${branch}.yaml"
+	# For our CI, we will query the local versions.yaml file both for kernel and
+	# all other subsystems. eg: a new version of NEMU would be good to test
+	# through CI. For the kernel, .ci/install_kata_kernel.sh file in tests
+	# repository will pass the kernel version as an override to this function to
+	# allow testing of kernels before they land in tree.
+	if ${CI}; then
+		info "Sourcing versions from local file found in runtime repository"
+		versions_file="${GOPATH}/src/${runtime_repo}/versions.yaml"
+	else
+		info "Sourcing versions from github ${branch} branch"
+		versions_file="versions-${branch}.yaml"
+	fi
 	if [ ! -e "${versions_file}" ]; then
 		yaml_url="https://raw.githubusercontent.com/kata-containers/runtime/${branch}/versions.yaml"
 		echo "versions file (${versions_file}) does not exist" >&2


### PR DESCRIPTION
the versions.yaml file in runtime carries the information on all the
components we use and ship with kata. It would be nice to have the CI
test the newer versions when the file is changed and CI is triggered.
The current code always fetches from the master tree from github and
that does not help to validate version changes before it lands in the
tree.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>