### PR TITLE
runtime: fix strict "= VERSION" dependencies for deb pkg

### DIFF
--- a/obs-packaging/build_all.sh
+++ b/obs-packaging/build_all.sh
@@ -76,6 +76,9 @@ main() {
 	local projectsList=("$@")
 	[ "${#projectsList[@]}" = "0" ] && projectsList=("${OBS_PKGS_PROJECTS[@]}")
 
+	# Make sure runtime is the last project
+	projectsList=($(echo "${projectsList[@]}" | sed -E "s/(^.*)(runtime)(.*$)/\1 \3 \2/"))
+
 	pushd "${script_dir}" >>/dev/null
 	local compare_result="$(./gen_versions_txt.sh --compare ${branch})"
 	[[ "$compare_result" =~ different ]] && die "$compare_result -- you need to run gen_versions_txt.sh"

--- a/obs-packaging/scripts/obs-pkgs.sh
+++ b/obs-packaging/scripts/obs-pkgs.sh
@@ -4,9 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-#Note:Lets update qemu and the kernel first, they take longer to build.
-#Note: runtime is build at the end to get the version from all its dependencies.
-OBS_PKGS_PROJECTS=(
+#NOTES:
+# - update qemu and the kernel first, they take longer to build
+# - runtime is always built at the end, as it depends on all the other listed
+# packages, and we need to get the full version of all those.
+
+typeset -a OBS_PKGS_PROJECTS
+
+[ "$(uname -m)" = "x86_64" ] && OBS_PKGS_PROJECTS+=(qemu-lite)
+
+OBS_PKGS_PROJECTS+=(
 	qemu-vanilla
 	linux-container
 	kata-containers-image
@@ -15,7 +22,3 @@ OBS_PKGS_PROJECTS=(
 	ksm-throttler
 	runtime
 )
-
-if [ "$(uname -m)" == "x86_64" ]; then
-	OBS_PKGS_PROJECTS=("qemu-lite" "${OBS_PKGS_PROJECTS[@]}")
-fi

--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -55,15 +55,15 @@ export GO_ARCH
 function display_help() {
 	cat <<-EOL
 		$SCRIPT_NAME
-		
+
 		This script is intended to create Kata Containers packages for the OBS
 		(Open Build Service) platform.
-		
+
 		    Usage:
 		        $SCRIPT_NAME [options]
-		
+
 		Options:
-		
+
 		    -l         --local-build     Build the runtime locally
 		    -b         --branch          Build with a given branch name
 		    -p         --push            Push changes to OBS
@@ -74,14 +74,14 @@ function display_help() {
 		    -C         --clean           Clean the repository
 		    -V         --verify          Verify the environment
 		    -h         --help            Display this help message
-		
+
 		    Usage examples:
-		
+
 		    $SCRIPT_NAME --local-build --branch staging
 		    $SCRIPT_NAME --push --api-url http://127.0.0.1
 		    $SCRIPT_NAME --push --obs-repository home:userx/repository
 		    $SCRIPT_NAME --push
-		
+
 	EOL
 	exit 1
 }


### PR DESCRIPTION
When specifying a "Depends: (= VERSION" match in deb packages, the full
"VERSION" needs to be specified, including any trailing release number.

A more relaxed alternative to this, without knowing the full version
of dependencies, is to specify each dependency as both ">= VERSION" and
"<< VERSION+1".

This fixes a regression introduced in: 63413814
Fixes: #531

Signed-off-by: Marco Vedovati <mvedovati@suse.com>