### PR TITLE
obs-packaging: Set debian Power arch as ppc64el

### DIFF
--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -45,6 +45,10 @@ short_commit_length=10
 
 arch=$(uname -m)
 DEB_ARCH=$(arch_to_golang "$arch")
+if [[ $DEB_ARCH == "ppc64le" ]]; then
+       DEB_ARCH="ppc64el"
+fi
+
 GO_ARCH=$(arch_to_golang "$arch")
 export GO_ARCH
 


### PR DESCRIPTION
Set debian Power arch as ppc64el not
ppc64le in debian.rules and .dsc files

Fixes: #533

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com