### PR TITLE
release: initialize CI variable in lib.sh

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -41,7 +41,7 @@ get_from_kata_deps() {
 	# through CI. For the kernel, .ci/install_kata_kernel.sh file in tests
 	# repository will pass the kernel version as an override to this function to
 	# allow testing of kernels before they land in tree.
-	if ${CI}; then
+	if [ "${CI:-}" = "true" ]; then
 		versions_file="${GOPATH}/src/${runtime_repo}/versions.yaml"
 	else
 		versions_file="versions-${branch}.yaml"


### PR DESCRIPTION
Recent change to always build tools from the local repository if the
script is run in a CI environment fails during a release build as the
variable ${CI} is not initialized. This fix addresses that issue.

Fixes: #537
Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>