### PR TITLE
static-builds: run docker commands using sudo

### DIFF
--- a/static-build/nemu/build-static-nemu.sh
+++ b/static-build/nemu/build-static-nemu.sh
@@ -13,6 +13,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/../../scripts/lib.sh"
 
 config_dir="${script_dir}/../../scripts/"
+nemu_tar="kata-nemu-static.tar.gz"
 
 nemu_repo="${nemu_repo:-}"
 nemu_version="${nemu_version:-}"
@@ -48,7 +49,7 @@ http_proxy="${http_proxy:-}"
 https_proxy="${https_proxy:-}"
 prefix="${prefix:-"/opt/kata"}"
 
-docker build \
+sudo docker build \
 	--build-arg http_proxy="${http_proxy}" \
 	--build-arg https_proxy="${https_proxy}" \
 	--build-arg NEMU_REPO="${nemu_repo}" \
@@ -61,7 +62,9 @@ docker build \
 	-f "${script_dir}/Dockerfile" \
 	-t nemu-static
 
-docker run \
+sudo docker run \
 	-i \
 	-v "${PWD}":/share nemu-static \
-	mv /tmp/nemu-static/kata-nemu-static.tar.gz /share/
+	mv "/tmp/nemu-static/${nemu_tar}" /share/
+
+sudo chown ${USER}:${USER} "${PWD}/${nemu_tar}"

--- a/static-build/qemu/build-static-qemu.sh
+++ b/static-build/qemu/build-static-qemu.sh
@@ -13,6 +13,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/../../scripts/lib.sh"
 
 config_dir="${script_dir}/../../scripts/"
+qemu_tar="kata-qemu-static.tar.gz"
 
 qemu_repo="${qemu_repo:-}"
 qemu_version="${qemu_version:-}"
@@ -33,7 +34,7 @@ info "Build ${qemu_repo} version: ${qemu_version}"
 http_proxy="${http_proxy:-}"
 https_proxy="${https_proxy:-}"
 
-docker build \
+sudo docker build \
 	--build-arg http_proxy="${http_proxy}" \
 	--build-arg https_proxy="${https_proxy}" \
 	--build-arg QEMU_REPO="${qemu_repo}" \
@@ -42,7 +43,9 @@ docker build \
 	-f "${script_dir}/Dockerfile" \
 	-t qemu-static
 
-docker run \
+sudo docker run \
 	-i \
 	-v "${PWD}":/share qemu-static \
-	mv /tmp/qemu-static/kata-qemu-static.tar.gz /share/
+	mv "/tmp/qemu-static/${qemu_tar}" /share/
+
+sudo chown ${USER}:${USER} "${PWD}/${qemu_tar}"


### PR DESCRIPTION
normal users might not have the correct permissions to run
docker without sudo.

In addition, as docker will run with sudo, fix permissions
on the qemu and nemu files.

Fixes: #544.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>