### PR TITLE
kata-pkgsync: vendor: update pkgcloud to add Fedora 30

### DIFF
--- a/cmd/kata-pkgsync/Gopkg.lock
+++ b/cmd/kata-pkgsync/Gopkg.lock
@@ -26,15 +26,14 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:237b43acafb17c01ca2939f940e61df737f2208c1646fe49abb7e4de781d6dd7"
+  digest = "1:c3d9c7aff913b274bb9cc000b57e87b721aa7296eeeb1ae8c0d1ccffcbc20c47"
   name = "github.com/mlafeldt/pkgcloud"
   packages = [
     ".",
     "upload",
   ]
   pruneopts = "UT"
-  revision = "49013a5afc7335e1d13d1f68be2a6a37496e6dc7"
+  revision = "926cf4b57c55666f6a386a50c2ab6581d15fd820"
 
 [[projects]]
   digest = "1:e8fcad58263a7511225a674d9c23b9c55aa2f8616e2dab59f184a516f55c6566"

--- a/cmd/kata-pkgsync/Gopkg.toml
+++ b/cmd/kata-pkgsync/Gopkg.toml
@@ -30,7 +30,7 @@
   name = "github.com/marcov/obsgo"
 
 [[constraint]]
-  branch = "master"
+  revision = "926cf4b57c55666f6a386a50c2ab6581d15fd820"
   name = "github.com/mlafeldt/pkgcloud"
 
 [[constraint]]

--- a/cmd/kata-pkgsync/vendor/github.com/mlafeldt/pkgcloud/distros.go
+++ b/cmd/kata-pkgsync/vendor/github.com/mlafeldt/pkgcloud/distros.go
@@ -104,4 +104,5 @@ var supportedDistros = map[string]int{
 	"fedora/29": 201,
 	"linuxmint/tessa": 202,
 	"ubuntu/disco": 203,
+	"fedora/30": 204,
 }


### PR DESCRIPTION
Update pkgcloud pacakge to add Fedora 30 to the list of distros
supported by to Packagecloud.

Shortlog since last vendoring of github.com/mlafeldt/pkgcloud:
    926cf4b Update list of distros (Add Fedora 30)

Fixes: #546
Signed-off-by: Marco Vedovati <mvedovati@suse.com>