### PR TITLE
QEMU: disable PAM authentication (used for VNC access)

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -217,6 +217,10 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-vnc-png)
 	qemu_options+=(size:--disable-vnc-sasl)
 
+	# Disable PAM authentication: it's a feature used together with VNC access
+	# that's not used. See QEMU commit 8953caf for more details
+	[ "${qemu_version_major}" -ge 4  ] && qemu_options+=(size:--disable-auth-pam)
+
 	# Disable unused filesystem support
 	[ "$arch" == x86_64 ] && qemu_options+=(size:--disable-fdt)
 	qemu_options+=(size:--disable-glusterfs)


### PR DESCRIPTION
Disable PAM authentication: it's a feature used together with VNC access
that's not used in Kata.

See QEMU commit 8953caf for more details on PAM auth.

Fixes: #550

Signed-off-by: Marco Vedovati <mvedovati@suse.com>