### PR TITLE
obs: distros: disble redhat build for x86_64

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -9,7 +9,8 @@ Debian_9::Debian:9.0::standard
 Fedora_28::Fedora:28::standard
 Fedora_29::Fedora:29::standard
 Fedora_30::Fedora:30::standard
-RHEL_7::RedHat:RHEL-7::standard
+# FIXME: https://github.com/kata-containers/packaging/issues/510
+#RHEL_7::RedHat:RHEL-7::standard
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 openSUSE_Leap_42.3::openSUSE:Leap:42.3::standard
 openSUSE_Leap_15.0::openSUSE:Leap:15.0::standard


### PR DESCRIPTION
The runtime package is faling to build due to
compatiblity issues  with gcc + golang because
the redhat version provided in OBS old.

Disable temporarily to allow release CI  work.