### PR TITLE
Enable flag to print out debug info in journalctl -t kata scope

### DIFF
--- a/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -28,6 +28,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ENABLE_DEBUG
+          value: "false"
         securityContext:
           privileged: false
         volumeMounts:

--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -52,6 +52,15 @@ function install_artifacts() {
 	echo "copying kata artifacts onto host"
 	cp -a /opt/kata-artifacts/opt/kata/* /opt/kata/
 	chmod +x /opt/kata/bin/*
+	if [ "$ENABLE_DEBUG" = true ]; then
+		for shim in ${shims[@]}; do
+			conf="/opt/kata/share/defaults/kata-containers/configuration-${shim}.toml"
+			cp $conf /tmp/configuration.toml
+			sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug agent.debug_console initcall_debug"/g' /tmp/configuration.toml
+			sed -i -e 's/^# *\(enable_debug\).*=.*$/\1 = true/g' /tmp/configuration.toml
+			awk '{if (/^\[proxy\.kata\]/) {got=1}; if (got == 1 && /^.*enable_debug/) {print "#enable_debug = true"; got=0; next; } else {print}}' /tmp/configuration.toml > $conf
+		done
+	fi
 }
 
 function configure_cri_runtime() {


### PR DESCRIPTION
Most likely not mergeable in its current format but it would be nice to be able to pass a flag to kata-deploy in this way.