### PR TITLE
nemu: enable compile nemu for arm64 on x86 host

### DIFF
--- a/static-build/nemu/Dockerfile_cross
+++ b/static-build/nemu/Dockerfile_cross
@@ -1,0 +1,70 @@
+# Copyright (c) 2019 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+FROM debian
+
+ARG NEMU_REPO
+ARG NEMU_VERSION
+ARG NEMU_OVMF
+ARG VIRTIOFSD_RELEASE
+ARG VIRTIOFSD
+ARG PREFIX
+ARG GEN_ARCH
+ARG DPKG_ARCH
+
+WORKDIR /root/nemu
+
+RUN echo "deb http://deb.debian.org/debian stable main" > /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian stable-updates main" >> /etc/apt/sources.list
+RUN echo "deb http://security.debian.org stable/updates main" >> /etc/apt/sources.list
+RUN dpkg --add-architecture $DPKG_ARCH
+
+RUN apt update && apt install -y \
+	autoconf \
+	automake \
+	bc \
+	bison \
+	cpio \
+	curl \
+	flex \
+	gawk \
+	git \
+	make \
+	pkg-config \
+	python \
+	python-dev \
+	rsync \
+	gcc-$GEN_ARCH-linux-gnu \
+	libaudit-dev:$DPKG_ARCH \
+	libcap-dev:$DPKG_ARCH \
+	libcap-ng-dev:$DPKG_ARCH \
+	libdw-dev:$DPKG_ARCH \
+	libelf-dev:$DPKG_ARCH \
+	libglib2.0-0:$DPKG_ARCH \
+	libglib2.0-dev:$DPKG_ARCH \
+	zlib1g-dev:$DPKG_ARCH \
+	librbd-dev:$DPKG_ARCH \
+	libltdl-dev:$DPKG_ARCH \
+	libpixman-1-dev:$DPKG_ARCH
+
+RUN cd  .. && git clone --depth=1 "${NEMU_REPO}" nemu
+RUN git fetch origin --tags && git checkout "${NEMU_VERSION}"
+RUN git clone https://github.com/qemu/capstone.git capstone
+RUN git clone https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
+ADD configure-hypervisor.sh /root/configure-hypervisor.sh
+RUN curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/gcc-defaults/pkg-config-"${GEN_ARCH}"-linux-gnu_7.4.0-1ubuntu2.3_amd64.deb && dpkg -i pkg*
+
+ENV PKG_CONFIG_PATH $PKG_CONFIG_PATH:/usr/lib/"${GEN_ARCH}"-linux-gnu/pkgconfig/:/usr/"${GEN_ARCH}"-linux-gnu/lib/pkgconfig
+RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-nemu ${GEN_ARCH} | xargs ./configure \
+       --with-pkgversion=kata-static
+RUN make -j$($(nproc)-1) CONFIG_HID_DEV=y
+RUN make install DESTDIR=/tmp/nemu-static
+
+RUN curl -O "${NEMU_OVMF}" && mv OVMF.fd /tmp/nemu-static/"${PREFIX}"/share/kata-nemu/
+RUN mv /tmp/nemu-static/"${PREFIX}"/bin/qemu-system-$GEN_ARCH /tmp/nemu-static/"${PREFIX}"/bin/nemu-system-$GEN_ARCH
+RUN curl -O "${VIRTIOFSD_RELEASE}/${VIRTIOFSD}" && chmod +x ${VIRTIOFSD} && mv ${VIRTIOFSD} /tmp/nemu-static/"${PREFIX}"/bin/
+
+RUN cd /tmp/nemu-static && tar -czvf kata-nemu-static.tar.gz *
+

--- a/static-build/nemu/Makefile
+++ b/static-build/nemu/Makefile
@@ -7,7 +7,7 @@ MK_DIR :=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 CONFIG_DIR := $(MK_DIR)/../../scripts/
 
 build:
-	"$(MK_DIR)/build-static-nemu.sh"
+	"$(MK_DIR)/build-static-nemu.sh" $(arch)
 
 clean:
 	rm -f kata-nemu-static.tar.gz

--- a/static-build/nemu/build-static-nemu.sh
+++ b/static-build/nemu/build-static-nemu.sh
@@ -15,6 +15,30 @@ source "${script_dir}/../../scripts/lib.sh"
 config_dir="${script_dir}/../../scripts/"
 nemu_tar="kata-nemu-static.tar.gz"
 
+if [ $# -ne 0 ];then
+       arch="$1"
+       case "$arch" in
+	       aarch64) dpkg_arch="arm64"
+		       Dockerfile="Dockerfile_cross"
+		       ;;
+	       ppc64le) arch="powerpc64le"
+		       dpkg_arch="ppc64el"
+		       Dockerfile="Dockerfile_cross"
+		       ;;
+	       s390x) dpkg_arch=$arch
+		       Dockerfile="Dockerfile_cross"
+		       ;;
+	       x86_64) dpkg_arch="amd64"
+		       $arch="amd64"
+		       Dockerfile="Dockerfile"
+		       ;;
+	       *) die "$arch is not support for cross compile" ;;
+       esac
+else
+       arch=""
+       dpkg_arch=""
+fi
+
 nemu_repo="${nemu_repo:-}"
 nemu_version="${nemu_version:-}"
 nemu_ovmf_repo="${nemu_ovmf_repo:-}"
@@ -58,8 +82,10 @@ sudo docker build \
 	--build-arg VIRTIOFSD_RELEASE="${nemu_virtiofsd_release}" \
 	--build-arg VIRTIOFSD="${nemu_virtiofsd_binary}" \
 	--build-arg PREFIX="${prefix}" \
+	--build-arg DPKG_ARCH="${dpkg_arch}" \
+	--build-arg GEN_ARCH="${arch}" \
 	"${config_dir}" \
-	-f "${script_dir}/Dockerfile" \
+	-f "${script_dir}/$Dockerfile" \
 	-t nemu-static
 
 sudo docker run \


### PR DESCRIPTION
This patch enable cross-compile nemu for arm64 in container
on x86 host.

fixed: #577
Signed-off-by: Jianyong Wu  <jianyong.wu@arm.com>
@jodh-intel @bergwolf @ganeshmaharaj @grahamwhaley @Pennyzct 