### PR TITLE
packages: update default VMM to qemu-vanilla

### DIFF
--- a/obs-packaging/runtime/debian.rules-template
+++ b/obs-packaging/runtime/debian.rules-template
@@ -12,7 +12,7 @@ export GOPATH=/usr/src/packages/BUILD/go
 export GOROOT=/usr/src/packages/BUILD/local/go
 export DH_OPTIONS
 
-export DEFAULT_QEMU=qemu-lite-system-x86_64
+export DEFAULT_QEMU=qemu-vanilla-x86_64
 
 GO_VERSION=@GO_VERSION@
 

--- a/obs-packaging/runtime/kata-runtime.spec-template
+++ b/obs-packaging/runtime/kata-runtime.spec-template
@@ -4,7 +4,7 @@
 %global IMPORTNAME %{DOMAIN}/%{ORG}/%{PROJECT}
 %global GO_VERSION @GO_VERSION@
 
-%global DEFAULT_QEMU qemu-lite-system-x86_64
+%global DEFAULT_QEMU qemu-vanilla-system-x86_64
 
 %define LIBEXECDIR /usr/libexec
 


### PR DESCRIPTION
We are looking to deprecate qemu-lite. As a first step,
let's go ahead and make qemu-vanilla (4.0) the default VMM.

Signed-off-by: Eric Ernst <eric.ernst@intel.com>