### PR TITLE
static-build: qemu: use tag if version doesn't exist

### DIFF
--- a/static-build/qemu/build-static-qemu.sh
+++ b/static-build/qemu/build-static-qemu.sh
@@ -26,6 +26,9 @@ fi
 [ -n "$qemu_repo" ] || die "failed to get qemu repo"
 
 [ -n "$qemu_version" ] || qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version")
+if ! (git ls-remote --heads "${qemu_url}" | grep -q "refs/heads/${qemu_version}"); then
+	qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.tag")
+fi
 [ -n "$qemu_version" ] || die "failed to get qemu version"
 
 info "Build ${qemu_repo} version: ${qemu_version}"


### PR DESCRIPTION
Use the tag of qemu from `versions.yaml` instead of the
version number if the version does not exist in the references
of the repository.

Fixes: #587.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>