### PR TITLE
static-build: qemu: be able to change prefix variable

### DIFF
--- a/static-build/qemu/Dockerfile
+++ b/static-build/qemu/Dockerfile
@@ -3,6 +3,7 @@ from ubuntu:16.04
 ARG QEMU_REPO
 # commit/tag/branch
 ARG QEMU_VERSION
+ARG PREFIX
 
 WORKDIR /root/qemu
 RUN apt-get update
@@ -39,7 +40,7 @@ RUN git clone  https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
 
 ADD configure-hypervisor.sh /root/configure-hypervisor.sh
 
-RUN PREFIX=/opt/kata /root/configure-hypervisor.sh -s kata-qemu | xargs ./configure \
+RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-qemu | xargs ./configure \
        --with-pkgversion=kata-static
 
 RUN make -j$(nproc)

--- a/static-build/qemu/build-static-qemu.sh
+++ b/static-build/qemu/build-static-qemu.sh
@@ -32,12 +32,14 @@ info "Build ${qemu_repo} version: ${qemu_version}"
 
 http_proxy="${http_proxy:-}"
 https_proxy="${https_proxy:-}"
+prefix="${prefix:-"/opt/kata"}"
 
 docker build \
 	--build-arg http_proxy="${http_proxy}" \
 	--build-arg https_proxy="${https_proxy}" \
 	--build-arg QEMU_REPO="${qemu_repo}" \
 	--build-arg QEMU_VERSION="${qemu_version}" \
+	--build-arg PREFIX="${prefix}" \
 	"${config_dir}" \
 	-f "${script_dir}/Dockerfile" \
 	-t qemu-static


### PR DESCRIPTION
Instead of always having `prefix` hardcoded to `/opt/kata`,
change the script to be able to take the value from an
enviroment variable.

Fixes: #589.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>