### PR TITLE
kata-deploy: Add jailer binary

### DIFF
--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -127,6 +127,7 @@ install_firecracker() {
 	info "Install static firecracker"
 	mkdir -p "${destdir}/opt/kata/bin/"
 	sudo install -D --owner root --group root --mode 0744  firecracker/firecracker-static "${destdir}/opt/kata/bin/firecracker"
+	sudo install -D --owner root --group root --mode 0744  firecracker/jailer-static "${destdir}/opt/kata/bin/jailer"
 
 }
 

--- a/static-build/firecracker/Makefile
+++ b/static-build/firecracker/Makefile
@@ -7,3 +7,4 @@ build:
 clean:
 	rm -rf "$(MK_DIR)/firecracker"
 	rm "$(MK_DIR)/firecracker-static"
+	rm "$(MK_DIR)/jailer-static"

--- a/static-build/firecracker/build-static-firecracker.sh
+++ b/static-build/firecracker/build-static-firecracker.sh
@@ -36,3 +36,4 @@ git checkout ${firecracker_version}
 ./tools/devtool --unattended build --release -- --features vsock
 
 ln -s ./build/release/firecracker ./firecracker-static
+ln -s ./build/release/jailer ./jailer-static


### PR DESCRIPTION
Add jailer binary to kata-deploy. It allows us to enable jailer
with firecracker.

Fixes: #593

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>