### PR TITLE
kata-deploy: Add jailer binary

### DIFF
--- a/static-build/firecracker/build-static-firecracker.sh
+++ b/static-build/firecracker/build-static-firecracker.sh
@@ -35,5 +35,5 @@ cd firecracker
 git checkout ${firecracker_version}
 ./tools/devtool --unattended build --release -- --features vsock
 
-ln -s ./build/release/firecracker ./firecracker-static
-ln -s ./build/release/jailer ./jailer-static
+ln -s ./build/release-musl/firecracker ./firecracker-static
+ln -s ./build/release-musl/jailer ./jailer-static


### PR DESCRIPTION
Add jailer binary to kata-deploy. It allows us to enable jailer
with firecracker.

Latest firecracker has moved the generated binaries to a new
location. Update the scripts to use the new location.

Fixes: #593

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>