### PR TITLE
kata-deploy:  Update scripts to support firecracker 0.17.0

### DIFF
--- a/static-build/firecracker/build-static-firecracker.sh
+++ b/static-build/firecracker/build-static-firecracker.sh
@@ -35,5 +35,5 @@ cd firecracker
 git checkout ${firecracker_version}
 ./tools/devtool --unattended build --release -- --features vsock
 
-ln -s ./build/release/firecracker ./firecracker-static
-ln -s ./build/release/jailer ./jailer-static
+ln -s ./build/release-musl/firecracker ./firecracker-static
+ln -s ./build/release-musl/jailer ./jailer-static


### PR DESCRIPTION
Latest firecracker has moved the generated binaries to a new
location. Update the scripts to use the new location.

Fixes: #599

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>