### PR TITLE
ci: Add intial pipeline to test OBS package generation

### DIFF
--- a/.ci/azure/pipelines/obs-packaging-ci.yml
+++ b/.ci/azure/pipelines/obs-packaging-ci.yml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- script: echo setup
+  displayName: 'setup CI'
+
+- script: |
+    echo This is an initial CI job
+  displayName: 'Run CI'


### PR DESCRIPTION
Add simple yaml definition to run job in azure pipelines.

Fixes: #480

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>