### PR TITLE
ci: Enable check VERSION among the components without the runtime

### DIFF
--- a/release/tag_repos_test.sh
+++ b/release/tag_repos_test.sh
@@ -20,3 +20,10 @@ echo "Check tag_repos.sh status"
 
 echo "Check tag_repos.sh create tags but not push"
 ./release/tag_repos.sh tag | grep "tags not pushed"
+
+echo "Check tag_repos.sh pre-release"
+./release/tag_repos.sh pre-release $(curl -sL https://raw.githubusercontent.com/kata-containers/runtime/master/VERSION) | grep "Not checking runtime"
+
+echo "Check tag_repos.sh pre-release with invalid information"
+./release/tag_repos.sh pre-release 1000000 | grep "ERROR" || true
+


### PR DESCRIPTION
The main purpose is that this script will be used to verify
that VERSION among the components are equal before merging the runtime.

Fixes #613

Depends-on: github.com/kata-containers/runtime#1858

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>