### PR TITLE
obs: dokcer: update leap image base.

### DIFF
--- a/obs-packaging/Dockerfile
+++ b/obs-packaging/Dockerfile
@@ -1,12 +1,9 @@
-FROM opensuse:leap
-
 ARG SUSE_VERSION=${SUSE_VERSION:-42.3}
+FROM opensuse/leap:${SUSE_VERSION}
+
 
 # Get OBS client, plugins and dependencies
 RUN zypper -v -n install osc-plugin-install vim curl bsdtar git sudo
-RUN curl -OkL https://download.opensuse.org/repositories/openSUSE:Tools/openSUSE_${SUSE_VERSION}/openSUSE:Tools.repo
-RUN zypper -n addrepo openSUSE:Tools.repo
-RUN zypper --gpg-auto-import-keys refresh
 RUN zypper -v -n install build \
     obs-service-tar_scm \
     obs-service-verify_file \


### PR DESCRIPTION
The image tag opensuse:leap not longer exist
use the the new image format.

Fixes: #615