### PR TITLE
scripts: update configure-hypervisor script to support QEMU 4.1

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -226,7 +226,13 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-glusterfs)
 	qemu_options+=(size:--disable-libiscsi)
 	qemu_options+=(size:--disable-libnfs)
-	qemu_options+=(size:--disable-libssh2)
+
+	# Starting from QEMU 4.1, libssh replaces to libssh2
+	if [ "$(echo "${qemu_version_major}.${qemu_version_minor}" >= 4.1 | bc)" == "1" ]; then
+		qemu_options+=(size:--disable-libssh)
+	else
+		qemu_options+=(size:--disable-libssh2)
+	fi
 
 	# Disable unused compression support
 	qemu_options+=(size:--disable-bzip2)


### PR DESCRIPTION
QEMU >= 4.1 uses libssh not libssh2

fixes #627

Signed-off-by: Julio Montes <julio.montes@intel.com>