### PR TITLE
obs-packaging: install images as read-only files

### DIFF
--- a/obs-packaging/kata-containers-image/debian.rules-template
+++ b/obs-packaging/kata-containers-image/debian.rules-template
@@ -9,8 +9,8 @@ override_dh_auto_install:
 	tar xzf /usr/src/packages/SOURCES/kata-containers.tar.gz -C /usr/src/packages/SOURCES/ ; \
 	image=$$(find /usr/src/packages/SOURCES/ -type f -name '*.img') ; \
 	initrd=$$(find /usr/src/packages/SOURCES/ -type f -name '*.initrd') ; \
-	install -D $${image} ./debian/kata-containers-image/usr/share/kata-containers/ ; \
-	install -D $${initrd} ./debian/kata-containers-image/usr/share/kata-containers/ ; \
+	install -m 0400 -D $${image} ./debian/kata-containers-image/usr/share/kata-containers/ ; \
+	install -m 0400 -D $${initrd} ./debian/kata-containers-image/usr/share/kata-containers/ ; \
 	ln -s /usr/share/kata-containers/$$(basename $${image}) \
 	./debian/kata-containers-image/usr/share/kata-containers/kata-containers.img ; \
 	ln -s /usr/share/kata-containers/$$(basename $${initrd}) \

--- a/obs-packaging/kata-containers-image/kata-containers-image.spec-template
+++ b/obs-packaging/kata-containers-image/kata-containers-image.spec-template
@@ -28,8 +28,8 @@ tar xfz kata-containers.tar.gz
 image=$(find ${PWD} -type f -name '*.img')
 initrd=$(find ${PWD} -type f -name '*.initrd')
 popd
-install -p "${image}" ${ImageDir}/
-install -p "${initrd}"  ${ImageDir}/
+install -m 0400 -p "${image}" ${ImageDir}/
+install -m 0400 -p "${initrd}"  ${ImageDir}/
 ln -s /usr/share/kata-containers/$(basename "${image}") ${ImageDir}/kata-containers.img
 ln -s /usr/share/kata-containers/$(basename "${initrd}")  ${ImageDir}/kata-containers-initrd.img
 


### PR DESCRIPTION
In order to improve the security of Kata, nothing should be able to modify
the images. It would be really bad if a malicious container or process
modified them.

fixes #631

Signed-off-by: Julio Montes <julio.montes@intel.com>