### PR TITLE
snap: add bc to build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -279,6 +279,7 @@ parts:
       - libfdt-dev
       - curl
       - libcapstone-dev
+      - bc
     override-build: |
       yq=$(realpath ../../yq/build/yq)
       pkg_name="qemu"


### PR DESCRIPTION
bc is required to build the snap in launchpad

fixes #635

Signed-off-by: Julio Montes <julio.montes@intel.com>