### PR TITLE
distros: add ubuntu 16.04 back

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -15,6 +15,5 @@ SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 openSUSE_Leap_42.3::openSUSE:Leap:42.3::standard
 openSUSE_Leap_15.0::openSUSE:Leap:15.0::standard
 openSUSE_Tumbleweed::openSUSE:Factory::snapshot
-# FIXME: https://github.com/kata-containers/packaging/issues/607
-#xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update
+xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update
 xUbuntu_18.04::Ubuntu:18.04::universe


### PR DESCRIPTION
Seems that OBS now fixed issues with ubuntu,
add it back.

Fixes: #607