### PR TITLE
scripts: fix detection of qemu 4.1

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -228,7 +228,7 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-libnfs)
 
 	# Starting from QEMU 4.1, libssh replaces to libssh2
-	if [ "$(echo "${qemu_version_major}.${qemu_version_minor}" >= 4.1 | bc)" == "1" ]; then
+	if [ "$(echo "${qemu_version_major}.${qemu_version_minor} >= 4.1" | bc)" == "1" ]; then
 		qemu_options+=(size:--disable-libssh)
 	else
 		qemu_options+=(size:--disable-libssh2)


### PR DESCRIPTION
quote `>= 4.1` to avoid bash redirects `echo`'s output to a
new file named `=`

fixes #652

Signed-off-by: Julio Montes <julio.montes@intel.com>