### PR TITLE
obs: wait: Fix error to detect building job

### DIFF
--- a/obs-packaging/scripts/obs-docker.sh
+++ b/obs-packaging/scripts/obs-docker.sh
@@ -27,7 +27,7 @@ user = ${OBS_USER}
 pass = ${OBS_PASS}
 eom
 		fi
-	) >> /dev/null
+	) >>/dev/null
 	if [ ! -e "${OSCRC}" ]; then
 		echo "${OSCRC}, please  do 'export OBS_USER=your_user ; export OBS_PASS=your_pass' to configure osc for first time."
 		exit 1
@@ -56,6 +56,7 @@ docker_run() {
 		--env GO_ARCH="${GO_ARCH}" \
 		--env PUSH="${PUSH:-}" \
 		--env DEBUG="${DEBUG:-}" \
+		--env OBS_PROJECT="${OBS_PROJECT:-}" \
 		--env OBS_SUBPROJECT="${OBS_SUBPROJECT:-}" \
 		-v "${cache_dir}":/var/tmp/osbuild-packagecache/ \
 		-v "${_obs_docker_packaging_repo_dir}":"${_obs_docker_packaging_repo_dir}" \


### PR DESCRIPTION
The job to wait for packages are built is failing randomly.

Seems that sometimes the command is not retuning and expected
out out and may be mask by the

while osc pr | grep; done

This probably can fail at osc pr but because it failed at
osc and not grep we consider is working.

First query the result, if fail the script will stop,
if not then try to find the string state=building.

Additionally, check for failed jobs in the same query to
stop the job earlier.

Fixes: #665

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>