### PR TITLE
kernel: Update README with right instructions

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -20,6 +20,8 @@ The `build-kernel.sh` script requires an installed Golang version matching the
 ## Setup kernel source code
 
 ```bash
+$ go get -d -u github.com/kata-containers/packaging
+$ cd $GOPATH/src/github.com/kata-containers/packaging/kernel
 $ ./build-kernel.sh setup
 ```
 


### PR DESCRIPTION
Fix the instructions in the README guide
when setting up kernel source code. 

Fixes:  #673

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>