### PR TITLE
OBS: upgrade openSUSE Leap version

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -13,8 +13,8 @@ Fedora_30::Fedora:30::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510
 #RHEL_7::RedHat:RHEL-7::standard
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
-openSUSE_Leap_42.3::openSUSE:Leap:42.3::standard
 openSUSE_Leap_15.0::openSUSE:Leap:15.0::standard
+openSUSE_Leap_15.1::openSUSE:Leap:15.1::standard
 openSUSE_Tumbleweed::openSUSE:Factory::snapshot
 xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update
 xUbuntu_18.04::Ubuntu:18.04::universe


### PR DESCRIPTION
Upgrade openSUSE Leap version from 42.3 to the latest 15.1, since 42.3
version is now discontinued.

Fixes: #637

Signed-off-by: Marco Vedovati <mvedovati@suse.com>