### PR TITLE
Revert "ci: don't run vm-factory tets in snap CI"

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -13,8 +13,6 @@ cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 source /etc/os-release
 
-SNAP_CI="${SNAP_CI:-false}"
-
 pushd "${tests_repo_dir}"
 .ci/run.sh
 popd


### PR DESCRIPTION
This reverts commit cfead00a9dadd8f5354e028e01747d7e1aca3a38.

The snap version in https://snapcraft.io/kata-containers is 1.8.0
that had included 76a5076e5671e7d76ca2964eb8ae15b530b92340.
So ci and run vm-factory tests with snap.

Fixes: #1495

Signed-off-by: Hui Zhu <teawater@antfin.com>