### PR TITLE
static-build: Fix build for Firecracker v0.18

### DIFF
--- a/static-build/firecracker/build-static-firecracker.sh
+++ b/static-build/firecracker/build-static-firecracker.sh
@@ -33,7 +33,7 @@ info "Build ${firecracker_repo} version: ${firecracker_version}"
 git clone ${firecracker_repo}
 cd firecracker
 git checkout ${firecracker_version}
-./tools/devtool --unattended build --release -- --features vsock
+./tools/devtool --unattended build --release
 
-ln -s ./build/release-musl/firecracker ./firecracker-static
-ln -s ./build/release-musl/jailer ./jailer-static
+ln -s ./build/cargo_target/x86_64-unknown-linux-musl/release/firecracker ./firecracker-static
+ln -s ./build/cargo_target/x86_64-unknown-linux-musl/release/jailer ./jailer-static


### PR DESCRIPTION
Removes `--vsock` flag when building Firecracker since
the flag was removed as vsock is enabled by default.

Also update the path where the binaries are placed.

Fixes: #739.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>