### PR TITLE
static-build: Add patch that adds time to virtiofsd seccomp

### DIFF
--- a/qemu/patches/virtiofsd/0001-add-time-to-seccomp.patch
+++ b/qemu/patches/virtiofsd/0001-add-time-to-seccomp.patch
@@ -1,0 +1,26 @@
+From 2317a63d2acab16be4655ec87542a2bf3d75551b Mon Sep 17 00:00:00 2001
+From: "Dr. David Alan Gilbert" <dgilbert@redhat.com>
+Date: Thu, 26 Sep 2019 18:41:34 +0100
+Subject: [PATCH] virtiofsd: Add time to seccomp
+
+Needed by static builds
+
+Signed-off-by: Dr. David Alan Gilbert <dgilbert@redhat.com>
+---
+ contrib/virtiofsd/seccomp.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/contrib/virtiofsd/seccomp.c b/contrib/virtiofsd/seccomp.c
+index 3b92c6ee13..374bab2bef 100644
+--- a/contrib/virtiofsd/seccomp.c
++++ b/contrib/virtiofsd/seccomp.c
+@@ -75,6 +75,7 @@ static const int syscall_whitelist[] = {
+ 	SCMP_SYS(setresuid),
+ 	SCMP_SYS(set_robust_list),
+ 	SCMP_SYS(symlinkat),
++	SCMP_SYS(time), /* Rarely needed, except on static builds */
+ 	SCMP_SYS(tgkill),
+ 	SCMP_SYS(unlinkat),
+ 	SCMP_SYS(utimensat),
+-- 
+2.21.0

--- a/static-build/qemu-virtiofs/Dockerfile
+++ b/static-build/qemu-virtiofs/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get install -y \
 	    libpixman-1-dev \
 	    libseccomp-dev \
 	    libtool \
+	    patch \
 	    pkg-config \
 	    pkg-config \
 	    python \
@@ -38,6 +39,8 @@ RUN apt-get install -y \
 
 RUN cd  .. && git clone "${QEMU_VIRTIOFS_REPO}" qemu-virtiofs
 RUN git checkout "${QEMU_VIRTIOFS_TAG}"
+ADD qemu/patches/virtiofsd/0001-add-time-to-seccomp.patch /root/0001-add-time-to-seccomp.patch
+RUN patch -p1 < /root/0001-add-time-to-seccomp.patch
 ADD scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
 RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-qemu | sed -e 's|--enable-rbd||g' -e 's|--disable-seccomp||g' | xargs ./configure \
 	--with-pkgversion=kata-static


### PR DESCRIPTION
time syscall on seccomp is needed to be able to build
virtiofsd successfully.
This patch is currently not availabe upstream, so lets
add it until it becomes available.
In addition, apply qemu/patches/virtiofsd/0001-add-time-to-seccomp.patch
to be able to build virtiofsd statically.