### PR TITLE
Release 1.9 improvements

### DIFF
--- a/release/update-repository-version.sh
+++ b/release/update-repository-version.sh
@@ -120,7 +120,15 @@ $(get_changes "$current_version")
 EOT
 	cat "${notes_file}"
 
-	git add -u
+	if (echo "${current_version}" | grep "alpha") && (echo "${new_version}" | grep -v "alpha");then
+		info "update move from alpha, check if new version is rc0"
+		if echo "$new_version" | grep -v "rc0"; then
+			die "bump should be from alph to rc0"
+		fi
+		info "OK"
+	fi
+
+	git add VERSION
 	info "Creating commit with new changes"
 	commit_msg="$(generate_commit $new_version $current_version)"
 	git commit -s -m "${commit_msg}"


### PR DESCRIPTION
- check if a bump goes from alpha to rc0. The tag automation will create branches if there is a rc0 tag,
better check we dont miss it.
- version all  repos. Add version to all kata repos.