### PR TITLE
nemu: Fix docker build context for nemu to support older docker versions

### DIFF
--- a/static-build/nemu/build-static-nemu.sh
+++ b/static-build/nemu/build-static-nemu.sh
@@ -13,7 +13,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/../../scripts/lib.sh"
 source "${script_dir}/../qemu.blacklist"
 
-config_dir="${script_dir}/../../scripts/"
+config_dir="${script_dir}/../.."
 nemu_tar="kata-nemu-static.tar.gz"
 nemu_tmp_tar="kata-nemu-static-tmp.tar.gz"
 Dockerfile="Dockerfile"


### PR DESCRIPTION
Make the build context of nemu to be consistent with qemu.

Fixes #752

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>