### PR TITLE
kata-deploy: Add qemu-virtiofs wrapper

### DIFF
--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -235,6 +235,12 @@ ${prefix}/bin/kata-runtime --kata-config "${prefix}/share/defaults/${project}/co
 EOT
 	sudo chmod +x kata-nemu
 
+	cat <<EOT | sudo tee kata-qemu-virtiofs
+#!/bin/bash
+${prefix}/bin/kata-runtime --kata-config "${prefix}/share/defaults/${project}/configuration-qemu-virtiofs.toml" \$@
+EOT
+	sudo chmod +x kata-qemu-virtiofs
+
 	popd
 }
 


### PR DESCRIPTION
Tarball is missing to provide a wrapper for qemu-virtiofs

Fixes: #756

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>