### PR TITLE
release: Fix typos and organization issues

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -1,20 +1,24 @@
-# Release tools
+# Release information
 
 * [Introduction](#introduction)
 * [Create a Kata Containers release](#create-a-kata-containers-release)
-* [`update-repository-version.sh`](#update-repository-versionsh)
-* [Update Kata projects to a new version](#update-kata-projects-to-a-new-version)
-* [`tag_repos.sh`](#tag_repossh)
+* [Release tools](#release-tools)
+  - [`update-repository-version.sh`](#update-repository-versionsh)
+  - [Update Kata projects to a new version](#update-kata-projects-to-a-new-version)
+  - [`tag_repos.sh`](#tag_repossh)
 
 ## Introduction
 
-This directory contains tools for Kata Containers releases.
+This directory contains information of the process and
+tools used for creating Kata Containers releases.
 
 ## Create a Kata Containers release
 
 See [the release documentation](release.md).
 
-## `update-repository-version.sh`
+## Release tools
+
+### `update-repository-version.sh`
 
 This script creates a GitHub pull request (a.k.a PR) to change the version in
 all the Kata repositories.
@@ -25,7 +29,7 @@ For more information on using the script, run the following:
 $ ./update-repository-version.sh -h
 ```
 
-## Update Kata projects to a new version
+### Update Kata projects to a new version
 
 Kata Containers is divided into multiple projects. With each release, all
 project versions are updated to keep the version consistent.
@@ -41,7 +45,7 @@ Kata repositories. These pull requests are tested by the Kata CI to ensure the
 entire project is working prior to the release. Next, the PR is approved and
 merged by Kata Containers members.
 
-## `tag_repos.sh`
+### `tag_repos.sh`
 
 After all the Kata repositories are updated with a new version, they need to be
 tagged.

--- a/release/release.md
+++ b/release/release.md
@@ -125,7 +125,7 @@ make sure the packages install and work. To help with this you can use the [pack
    Publish in [Slack and Kata mailing list][join-us-kata] that new release is ready.
 
 8. Send changes to upstream.
-If you found any issue during the release process and you fix it, please send it back.
+If you found any issue during the release process and you fixed it, please send it back.
 After your changes are merged, tag Kata packaging with `${NEW_VERSION}` to identify the code used for the release.
 
 

--- a/release/runtime-release-notes.sh
+++ b/release/runtime-release-notes.sh
@@ -72,7 +72,7 @@ get_release_info() {
 }
 
 changes() {
-	echo "**FIXME - massage this section by hand to produce a summary please**"
+	echo "**FIXME - message this section by hand to produce a summary please**"
 
 	echo "### Shortlog"
 	for cr in $(git log --merges "${previous_release}".."${new_release}" | grep 'Merge:' | awk '{print $2".."$3}'); do


### PR DESCRIPTION
For better reading, re-orginize the `release/README.md`
and fix a typo in `runtime-release-notes.sh`.

Fixes: #769.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>