### PR TITLE
kata-deploy: fix qemu-virtiofs entry on crio configuration

### DIFF
--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -95,7 +95,7 @@ EOT
 		cat <<EOT | tee -a "$crio_conf_file"
 
 # Path to the Kata Containers runtime binary that uses the QEMU hypervisor with virtiofs support.
-[$kata_qemu_conf]
+[$kata_qemu_virtiofs_conf]
   runtime_path = "${kata_qemu_virtiofs_path}"
 EOT
         fi


### PR DESCRIPTION
Use correct key for the kata-qemu-virtiofs runtime class definition
in the crio configuration file.

Fixes: #771.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>