### PR TITLE
CI: Fix bump test

### DIFF
--- a/release/update-repository-version_test.sh
+++ b/release/update-repository-version_test.sh
@@ -48,7 +48,7 @@ output_should_contain "${out}" "Usage"
 OK
 
 echo "Local update version update should work"
-new_version=50.0.0
+new_version="50.0.0-rc0"
 out=$("${script_dir}/update-repository-version.sh" "${new_version}" "master" 2>&1)
 output_should_contain "${out}" "release: Kata Containers ${new_version}"
 OK


### PR DESCRIPTION
Bump test fails because Kata  version at this moment is alfa and
only bumps from alpha to rc0 are allowed. Just use rc0 as use-case
for all, there is not any other constrain at the moment.

Fixes: #795

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>