### PR TITLE
qemu-virtiofs: Add one patch to fix libvhost-user

### DIFF
--- a/qemu/patches/virtiofsd/0002-libvhost-user-Fix-the-VHOST_USER_PROTOCOL_F_SLAVE_SE.patch
+++ b/qemu/patches/virtiofsd/0002-libvhost-user-Fix-the-VHOST_USER_PROTOCOL_F_SLAVE_SE.patch
@@ -1,0 +1,50 @@
+From 47adda63e398a179b6211763377c8f61c5d62f5a Mon Sep 17 00:00:00 2001
+From: Sebastien Boeuf <sebastien.boeuf@intel.com>
+Date: Wed, 7 Aug 2019 07:15:32 -0700
+Subject: [PATCH] libvhost-user: Fix the VHOST_USER_PROTOCOL_F_SLAVE_SEND_FD
+ check
+
+Vhost user protocol features are set as a bitmask. And the following
+constant VHOST_USER_PROTOCOL_F_SLAVE_SEND_FD value is 10 because the bit
+10 indicates if the features is set or not.
+
+The proper way to check for the presence or absence of this feature is
+to shift 1 by the value of this constant and then mask it with the
+actual bitmask representing the supported protocol features.
+
+This patch aims to fix the current code as it was not doing the
+shifting, but instead it was masking directly with the value of the
+constant itself.
+
+Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
+---
+ contrib/libvhost-user/libvhost-user.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/contrib/libvhost-user/libvhost-user.c b/contrib/libvhost-user/libvhost-user.c
+index 215ce22b79..626e2a035f 100644
+--- a/contrib/libvhost-user/libvhost-user.c
++++ b/contrib/libvhost-user/libvhost-user.c
+@@ -1129,7 +1129,8 @@ bool vu_set_queue_host_notifier(VuDev *dev, VuVirtq *vq, int fd,
+ 
+     vmsg.fd_num = fd_num;
+ 
+-    if ((dev->protocol_features & VHOST_USER_PROTOCOL_F_SLAVE_SEND_FD) == 0) {
++    if ((dev->protocol_features &
++        (1ULL << VHOST_USER_PROTOCOL_F_SLAVE_SEND_FD)) == 0) {
+         return false;
+     }
+ 
+@@ -2554,7 +2555,8 @@ int64_t vu_fs_cache_request(VuDev *dev, VhostUserSlaveRequest req, int fd,
+ 
+     vmsg.fd_num = fd_num;
+ 
+-    if ((dev->protocol_features & VHOST_USER_PROTOCOL_F_SLAVE_SEND_FD) == 0) {
++    if ((dev->protocol_features &
++        (1ULL << VHOST_USER_PROTOCOL_F_SLAVE_SEND_FD)) == 0) {
+         return -EINVAL;
+     }
+ 
+-- 
+2.20.1
+

--- a/static-build/qemu-virtiofs/Dockerfile
+++ b/static-build/qemu-virtiofs/Dockerfile
@@ -42,6 +42,7 @@ RUN cd  .. && git clone "${QEMU_VIRTIOFS_REPO}" qemu-virtiofs
 RUN git checkout "${QEMU_VIRTIOFS_TAG}"
 ADD qemu/patches/virtiofsd/0001-add-time-to-seccomp.patch /root/0001-add-time-to-seccomp.patch
 RUN patch -p1 < /root/0001-add-time-to-seccomp.patch
+RUN patch -p1 < /root/0002-libvhost-user-Fix-the-VHOST_USER_PROTOCOL_F_SLAVE_SE.patch
 ADD scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
 RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-qemu | sed -e 's|--enable-rbd||g' -e 's|--disable-seccomp||g' | xargs ./configure \
 	--with-pkgversion=kata-static


### PR DESCRIPTION
In order to get both QEMU and Cloud-Hypervisor working with virtio-fs, a
patch needs to be applied in order to fix a libvhost-user bug.

Fixes #810

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>