### PR TITLE
obs: Do not wait on excluded packages

### DIFF
--- a/obs-packaging/wait-obs.sh
+++ b/obs-packaging/wait-obs.sh
@@ -50,14 +50,15 @@ wait_finish_building() {
 			echo "Project ${project} has blocked packages, waiting"
 			continue
 		fi
-		if echo "${out}" | grep 'code="excluded"'; then
-			echo "Project ${project} has excluded packages, waiting"
-			continue
-		fi
 		if echo "${out}" | grep 'state="building"'; then
 			echo "Project ${project} is still building, waiting"
 			continue
 		fi
+		if echo "${out}" | grep 'code="excluded"'; then
+			echo "Project ${project} has excluded packages left, quit waiting"
+			break
+		fi
+
 		echo "No jobs with building status were found"
 		echo "${out}"
 		break


### PR DESCRIPTION
In case a package in obs is excluded ie no longer being built,
do not wait for it to be built. Wait as long as there are packages
being built or blocked on others to be built.

Fixes #815

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>