### PR TITLE
obs: Add fakeroot dependency for ubuntu 19.04

### DIFF
--- a/obs-packaging/ksm-throttler/kata-ksm-throttler.dsc-template
+++ b/obs-packaging/ksm-throttler/kata-ksm-throttler.dsc-template
@@ -6,7 +6,7 @@ Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
 Homepage: https://katacontainers.io
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, pkg-config, dh-systemd, systemd
+Build-Depends: dh-make, git, ca-certificates, fakeroot, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make, pkg-config, dh-systemd, systemd
 Debtransform-Tar: kata-ksm-throttler-@VERSION@.tar.gz
 
 Package: kata-ksm-throttler

--- a/obs-packaging/proxy/kata-proxy.dsc-template
+++ b/obs-packaging/proxy/kata-proxy.dsc-template
@@ -5,7 +5,7 @@ Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper, build-essential, dh-autoreconf, make
+Build-Depends: dh-make, git, ca-certificates, execstack, fakeroot, devscripts, debhelper, build-essential, dh-autoreconf, make
 Homepage: https://katacontainers.io
 Debtransform-Tar: kata-proxy-@VERSION@.tar.gz
 

--- a/obs-packaging/runtime/kata-runtime.dsc-template
+++ b/obs-packaging/runtime/kata-runtime.dsc-template
@@ -7,7 +7,7 @@ Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
-Build-Depends: dh-make, git, ca-certificates, execstack, devscripts, debhelper,
+Build-Depends: dh-make, git, ca-certificates, execstack, fakeroot, devscripts, debhelper,
                build-essential, dh-autoreconf, make
 Homepage: https://katacontainers.io
 Debtransform-Tar: kata-runtime-@VERSION@.tar.gz

--- a/obs-packaging/shim/kata-shim.dsc-template
+++ b/obs-packaging/shim/kata-shim.dsc-template
@@ -5,7 +5,7 @@ Section: devel
 Priority: optional
 Maintainer: Kata containers team <https://github.com/kata-containers/>
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 9), git, ca-certificates, execstack, devscripts, dh-make
+Build-Depends: debhelper (>= 9), git, ca-certificates, execstack, fakeroot, devscripts, dh-make
 Homepage: https://katacontainers.io
 Debtransform-Tar: kata-shim-@VERSION@.tar.gz
 


### PR DESCRIPTION
It seems that to build ksm-throttler, proxy, runtime and shim OBS packages
for ubuntu 19.04, we need fakeroot to avoid having unresolvable packages. This adds that dependency so we can build them.

Fixes #776

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>