### PR TITLE
obs: Failed when we have unresolvable packages

### DIFF
--- a/obs-packaging/wait-obs.sh
+++ b/obs-packaging/wait-obs.sh
@@ -50,6 +50,10 @@ wait_finish_building() {
 			echo "Project ${project} has blocked packages, waiting"
 			continue
 		fi
+		if echo "${out}" | grep 'code="unresolvable"'; then
+			echo "Project ${project} has unresolvable packages"
+			exit 1
+		fi
 		if echo "${out}" | grep 'state="building"'; then
 			echo "Project ${project} is still building, waiting"
 			continue


### PR DESCRIPTION
We need to fail when we have unresolvable packages as they are not build
correctly.

Fixes #820

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>