### PR TITLE
Backport tarball renaming changes related to github actions to 1.9

### DIFF
--- a/kernel/build-kernel.sh
+++ b/kernel/build-kernel.sh
@@ -14,6 +14,7 @@ set -o pipefail
 
 readonly script_name="$(basename "${BASH_SOURCE[0]}")"
 readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+kata_version="${kata_version:-}"
 
 #project_name
 readonly project_name="kata-containers"
@@ -426,9 +427,9 @@ main() {
 	# If not kernel version take it from versions.yaml
 	if [ -z "$kernel_version" ]; then
 		if [[ ${experimental_kernel} == "true" ]]; then
-			kernel_version=$(get_from_kata_deps "assets.kernel-experimental.tag")
+			kernel_version=$(get_from_kata_deps "assets.kernel-experimental.tag" "${kata_version}")
 		else
-			kernel_version=$(get_from_kata_deps "assets.kernel.version")
+			kernel_version=$(get_from_kata_deps "assets.kernel.version" "${kata_version}")
 			#Remove extra 'v'
 			kernel_version="${kernel_version#v}"
 		fi

--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -110,7 +110,7 @@ install_image() {
 	ln -sf "${initrd}" kata-containers-initrd.img
 	popd >>/dev/null
 	pushd ${destdir}
-	tar -czvf ../kata-image.tar.gz *
+	tar -czvf ../kata-static-image.tar.gz *
 	popd
 }
 
@@ -124,7 +124,7 @@ install_kernel() {
 	DESTDIR="${destdir}" PREFIX="${prefix}" ./kernel/build-kernel.sh install
 	popd
 	pushd ${destdir}
-	tar -czvf ../kata-kernel.tar.gz *
+	tar -czvf ../kata-static-kernel.tar.gz *
 	popd
 }
 
@@ -138,7 +138,7 @@ install_experimental_kernel() {
 	DESTDIR="${destdir}" PREFIX="${prefix}" ./kernel/build-kernel.sh -e install
 	popd
 	pushd ${destdir}
-	tar -czvf ../kata-kernel-experimental.tar.gz *
+	tar -czvf ../kata-static-experimental-kernel.tar.gz *
 	popd
 }
 
@@ -169,7 +169,7 @@ install_firecracker() {
 	sudo install -D --owner root --group root --mode 0744  firecracker/firecracker-static "${destdir}/opt/kata/bin/firecracker"
 	sudo install -D --owner root --group root --mode 0744  firecracker/jailer-static "${destdir}/opt/kata/bin/jailer"
 	pushd ${destdir}
-	tar -czvf ../kata-firecracker-static.tar.gz *
+	tar -czvf ../kata-static-firecracker.tar.gz *
 	popd
 }
 
@@ -237,17 +237,17 @@ EOT
 
 	popd
 	pushd ${destdir}
-	tar -czvf ../kata-components.tar.gz *
+	tar -czvf ../kata-static-kata-components.tar.gz *
 	popd
 }
 
 untar_qemu_binaries() {
 	info "Install static qemu"
-	tar xf kata-qemu-static.tar.gz -C "${destdir}"
+	tar xf kata-static-qemu.tar.gz -C "${destdir}"
 	info "Install static nemu"
-	tar xf kata-nemu-static.tar.gz -C "${destdir}"
+	tar xf kata-static-nemu.tar.gz -C "${destdir}"
 	info "Install static qemu-virtiofs"
-	tar xf kata-qemu-virtiofs-static.tar.gz -C "${destdir}"
+	tar xf kata-static-qemu-virtiofsd.tar.gz -C "${destdir}"
 }
 
 main() {

--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -116,12 +116,13 @@ install_image() {
 
 #Install kernel asset
 install_kernel() {
+	kata_version=${1:-$kata_version}
 	pushd "${script_dir}/../"
 	info "build kernel"
 	./kernel/build-kernel.sh setup
 	./kernel/build-kernel.sh build
 	info "install kernel"
-	DESTDIR="${destdir}" PREFIX="${prefix}" ./kernel/build-kernel.sh install
+	kata_version=$kata_version DESTDIR="${destdir}" PREFIX="${prefix}" ./kernel/build-kernel.sh install
 	popd
 	pushd ${destdir}
 	tar -czvf ../kata-static-kernel.tar.gz *
@@ -130,12 +131,13 @@ install_kernel() {
 
 #Install experimental kernel asset
 install_experimental_kernel() {
+	kata_version=${1:-$kata_version}
 	pushd "${script_dir}/../"
 	info "build experimental kernel"
 	./kernel/build-kernel.sh -e setup
 	./kernel/build-kernel.sh -e build
 	info "install experimental kernel"
-	DESTDIR="${destdir}" PREFIX="${prefix}" ./kernel/build-kernel.sh -e install
+	kata_version=$kata_version DESTDIR="${destdir}" PREFIX="${prefix}" ./kernel/build-kernel.sh -e install
 	popd
 	pushd ${destdir}
 	tar -czvf ../kata-static-experimental-kernel.tar.gz *
@@ -144,26 +146,30 @@ install_experimental_kernel() {
 
 # Install static nemu asset
 install_nemu() {
+	kata_version=${1:-$kata_version}
 	info "build static nemu"
-	"${script_dir}/../static-build/nemu/build-static-nemu.sh"
+	kata_version=$kata_version "${script_dir}/../static-build/nemu/build-static-nemu.sh"
 }
 
 # Install static qemu asset
 install_qemu() {
+	kata_version=${1:-$kata_version}
 	info "build static qemu"
-	"${script_dir}/../static-build/qemu/build-static-qemu.sh"
+	kata_version=$kata_version "${script_dir}/../static-build/qemu/build-static-qemu.sh"
 }
 
 # Install static qemu-virtiofsd asset
 install_qemu_virtiofsd() {
+	kata_version=${1:-$kata_version}
 	info "build static qemu-virtiofs"
-	"${script_dir}/../static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh"
+	kata_version=$kata_version "${script_dir}/../static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh"
 }
 
 # Install static firecracker asset
 install_firecracker() {
+	kata_version=${1:-$kata_version}
 	info "build static firecracker"
-	[ -f "firecracker/firecracker-static" ] || "${script_dir}/../static-build/firecracker/build-static-firecracker.sh"
+	[ -f "firecracker/firecracker-static" ] || kata_version=$kata_version "${script_dir}/../static-build/firecracker/build-static-firecracker.sh"
 	info "Install static firecracker"
 	mkdir -p "${destdir}/opt/kata/bin/"
 	sudo install -D --owner root --group root --mode 0744  firecracker/firecracker-static "${destdir}/opt/kata/bin/firecracker"

--- a/static-build/firecracker/build-static-firecracker.sh
+++ b/static-build/firecracker/build-static-firecracker.sh
@@ -16,16 +16,17 @@ config_dir="${script_dir}/../../scripts/"
 
 firecracker_repo="${firecracker_repo:-}"
 firecracker_version="${firecracker_version:-}"
+kata_version="${kata_version:-}"
 
 if [ -z "$firecracker_repo" ]; then
 	info "Get firecracker information from runtime versions.yaml"
-        firecracker_url=$(get_from_kata_deps "assets.hypervisor.firecracker.url")
+        firecracker_url=$(get_from_kata_deps "assets.hypervisor.firecracker.url" "${kata_version}")
 	[ -n "$firecracker_url" ] || die "failed to get firecracker url"
         firecracker_repo="${firecracker_url}.git"
 fi
 [ -n "$firecracker_repo" ] || die "failed to get firecracker repo"
 
-[ -n "$firecracker_version" ] || firecracker_version=$(get_from_kata_deps "assets.hypervisor.firecracker.version")
+[ -n "$firecracker_version" ] || firecracker_version=$(get_from_kata_deps "assets.hypervisor.firecracker.version" "${kata_version}")
 [ -n "$firecracker_version" ] || die "failed to get firecracker version"
 
 info "Build ${firecracker_repo} version: ${firecracker_version}"

--- a/static-build/nemu/Dockerfile
+++ b/static-build/nemu/Dockerfile
@@ -57,4 +57,4 @@ RUN wget "${NEMU_OVMF}" && mv OVMF.fd /tmp/nemu-static/"${PREFIX}"/share/kata-ne
 RUN mv /tmp/nemu-static/"${PREFIX}"/bin/qemu-system-x86_64 /tmp/nemu-static/"${PREFIX}"/bin/nemu-system-x86_64
 RUN wget "${VIRTIOFSD_RELEASE}/${VIRTIOFSD}" && chmod +x ${VIRTIOFSD} && mv ${VIRTIOFSD} /tmp/nemu-static/"${PREFIX}"/bin/
 
-RUN cd /tmp/nemu-static && tar -czvf kata-nemu-static.tar.gz *
+RUN cd /tmp/nemu-static && tar -czvf kata-static-nemu.tar.gz *

--- a/static-build/nemu/build-static-nemu.sh
+++ b/static-build/nemu/build-static-nemu.sh
@@ -45,24 +45,25 @@ nemu_repo="${nemu_repo:-}"
 nemu_version="${nemu_version:-}"
 nemu_ovmf_repo="${nemu_ovmf_repo:-}"
 nemu_ovmf_version="${nemu_ovmf_version:-}"
+kata_version="${kata_version:-}"
 
 if [ -z "$nemu_repo" ]; then
 	info "Get nemu information from runtime versions.yaml"
-	nemu_repo=$(get_from_kata_deps "assets.hypervisor.nemu.url")
+	nemu_repo=$(get_from_kata_deps "assets.hypervisor.nemu.url" "${kata_version}")
 fi
 [ -n "$nemu_repo" ] || die "failed to get nemu repo"
 
-[ -n "$nemu_version" ] || nemu_version=$(get_from_kata_deps "assets.hypervisor.nemu.version")
+[ -n "$nemu_version" ] || nemu_version=$(get_from_kata_deps "assets.hypervisor.nemu.version" "${kata_version}")
 [ -n "$nemu_version" ] || die "failed to get nemu version"
 
 if [ -z "$nemu_ovmf_repo" ]; then
 	info "Get nemu information from runtime versions.yaml"
-	nemu_ovmf_repo=$(get_from_kata_deps "assets.hypervisor.nemu-ovmf.url")
+	nemu_ovmf_repo=$(get_from_kata_deps "assets.hypervisor.nemu-ovmf.url" "${kata_version}")
 	[ -n "$nemu_ovmf_repo" ] || die "failed to get nemu ovmf repo url"
 fi
 
 if [ -z "$nemu_ovmf_version" ]; then
-	nemu_ovmf_version=$(get_from_kata_deps "assets.hypervisor.nemu-ovmf.version")
+	nemu_ovmf_version=$(get_from_kata_deps "assets.hypervisor.nemu-ovmf.version" "${kata_version}")
 	[ -n "$nemu_ovmf_version" ] || die "failed to get nemu ovmf version"
 fi
 

--- a/static-build/nemu/build-static-nemu.sh
+++ b/static-build/nemu/build-static-nemu.sh
@@ -14,8 +14,8 @@ source "${script_dir}/../../scripts/lib.sh"
 source "${script_dir}/../qemu.blacklist"
 
 config_dir="${script_dir}/../../scripts/"
-nemu_tar="kata-nemu-static.tar.gz"
-nemu_tmp_tar="kata-nemu-static-tmp.tar.gz"
+nemu_tar="kata-static-nemu.tar.gz"
+nemu_tmp_tar="kata-static-nemu-tmp.tar.gz"
 Dockerfile="Dockerfile"
 
 if [ $# -ne 0 ];then

--- a/static-build/qemu-virtiofs/Dockerfile
+++ b/static-build/qemu-virtiofs/Dockerfile
@@ -3,6 +3,7 @@ from ubuntu:18.04
 ARG QEMU_VIRTIOFS_REPO
 # commit/tag/branch
 ARG QEMU_VIRTIOFS_TAG
+ARG QEMU_TARBALL
 ARG PREFIX
 
 WORKDIR /root/qemu-virtiofs
@@ -49,4 +50,4 @@ RUN make -j$(nproc) virtiofsd
 RUN make install DESTDIR=/tmp/qemu-virtiofs-static
 RUN mv /tmp/qemu-virtiofs-static/"${PREFIX}"/bin/qemu-system-x86_64 /tmp/qemu-virtiofs-static/"${PREFIX}"/bin/qemu-virtiofs-system-x86_64
 RUN chmod +x virtiofsd && mv virtiofsd /tmp/qemu-virtiofs-static/opt/kata/bin/
-RUN cd /tmp/qemu-virtiofs-static && tar -czvf kata-qemu-static.tar.gz *
+RUN cd /tmp/qemu-virtiofs-static && tar -czvf "${QEMU_TARBALL}"  *

--- a/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
+++ b/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
@@ -17,9 +17,8 @@ packaging_dir="${script_dir}/../.."
 qemu_virtiofs_repo=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.url")
 # This tag will be supported on the runtime versions.yaml
 qemu_virtiofs_tag=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.tag")
-qemu_tar="kata-qemu-static.tar.gz"
-qemu_virtiofs_tar="kata-qemu-virtiofs-static.tar.gz"
-qemu_tmp_tar="kata-qemu-virtiofs-static-tmp.tar.gz"
+qemu_virtiofs_tar="kata-static-qemu-virtiofsd.tar.gz"
+qemu_tmp_tar="kata-static-qemu-virtiofsd-tmp.tar.gz"
 
 info "Build ${qemu_virtiofs_repo} tag: ${qemu_virtiofs_tag}"
 
@@ -41,10 +40,10 @@ sudo docker build \
 sudo docker run \
 	-i \
 	-v "${PWD}":/share qemu-virtiofs-static \
-	mv "/tmp/qemu-virtiofs-static/${qemu_tar}" /share/
+	mv "/tmp/qemu-virtiofs-static/${qemu_virtiofs_tar}" /share/
 
-sudo chown ${USER}:${USER} "${PWD}/${qemu_tar}"
+sudo chown ${USER}:${USER} "${PWD}/${qemu_virtiofs_tar}"
 
 # Remove blacklisted binaries
-gzip -d < "${qemu_tar}" | tar --delete --wildcards -f - ${qemu_black_list[*]} | gzip > "${qemu_tmp_tar}"
+gzip -d < "${qemu_virtiofs_tar}" | tar --delete --wildcards -f - ${qemu_black_list[*]} | gzip > "${qemu_tmp_tar}"
 mv -f "${qemu_tmp_tar}" "${qemu_virtiofs_tar}"

--- a/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
+++ b/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
@@ -13,10 +13,11 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/../../scripts/lib.sh"
 source "${script_dir}/../qemu.blacklist"
 
+kata_version="${kata_version:-}"
 packaging_dir="${script_dir}/../.."
-qemu_virtiofs_repo=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.url")
+qemu_virtiofs_repo=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.url" "${kata_version}")
 # This tag will be supported on the runtime versions.yaml
-qemu_virtiofs_tag=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.tag")
+qemu_virtiofs_tag=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.tag" "${kata_version}") 
 qemu_virtiofs_tar="kata-static-qemu-virtiofsd.tar.gz"
 qemu_tmp_tar="kata-static-qemu-virtiofsd-tmp.tar.gz"
 

--- a/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
+++ b/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
@@ -32,6 +32,7 @@ sudo docker build \
 	--build-arg https_proxy="${https_proxy}" \
 	--build-arg QEMU_VIRTIOFS_REPO="${qemu_virtiofs_repo}" \
 	--build-arg QEMU_VIRTIOFS_TAG="${qemu_virtiofs_tag}" \
+	--build-arg QEMU_TARBALL="${qemu_virtiofs_tar}" \
 	--build-arg PREFIX="${prefix}" \
 	"${packaging_dir}" \
 	-f "${script_dir}/Dockerfile" \

--- a/static-build/qemu/Dockerfile
+++ b/static-build/qemu/Dockerfile
@@ -3,6 +3,7 @@ from ubuntu:18.04
 ARG QEMU_REPO
 # commit/tag/branch
 ARG QEMU_VERSION
+ARG QEMU_TARBALL
 ARG PREFIX
 
 WORKDIR /root/qemu
@@ -54,4 +55,4 @@ RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-qemu | xargs ./conf
 
 RUN make -j$(nproc)
 RUN make install DESTDIR=/tmp/qemu-static
-RUN cd /tmp/qemu-static && tar -czvf kata-qemu-static.tar.gz *
+RUN cd /tmp/qemu-static && tar -czvf "${QEMU_TARBALL}" *

--- a/static-build/qemu/build-static-qemu.sh
+++ b/static-build/qemu/build-static-qemu.sh
@@ -14,8 +14,8 @@ source "${script_dir}/../../scripts/lib.sh"
 source "${script_dir}/../qemu.blacklist"
 
 packaging_dir="${script_dir}/../.."
-qemu_tar="kata-qemu-static.tar.gz"
-qemu_tmp_tar="kata-qemu-static-tmp.tar.gz"
+qemu_tar="kata-static-qemu.tar.gz"
+qemu_tmp_tar="kata-static-qemu-tmp.tar.gz"
 
 qemu_repo="${qemu_repo:-}"
 qemu_version="${qemu_version:-}"

--- a/static-build/qemu/build-static-qemu.sh
+++ b/static-build/qemu/build-static-qemu.sh
@@ -46,6 +46,7 @@ sudo docker build \
 	--build-arg https_proxy="${https_proxy}" \
 	--build-arg QEMU_REPO="${qemu_repo}" \
 	--build-arg QEMU_VERSION="${qemu_version}" \
+	--build-arg QEMU_TARBALL="${qemu_tar}" \
 	--build-arg PREFIX="${prefix}" \
 	"${packaging_dir}" \
 	-f "${script_dir}/Dockerfile" \

--- a/static-build/qemu/build-static-qemu.sh
+++ b/static-build/qemu/build-static-qemu.sh
@@ -19,18 +19,19 @@ qemu_tmp_tar="kata-static-qemu-tmp.tar.gz"
 
 qemu_repo="${qemu_repo:-}"
 qemu_version="${qemu_version:-}"
+kata_version="${kata_version:-}"
 
 if [ -z "$qemu_repo" ]; then
 	info "Get qemu information from runtime versions.yaml"
-	qemu_url=$(get_from_kata_deps "assets.hypervisor.qemu.url")
+	qemu_url=$(get_from_kata_deps "assets.hypervisor.qemu.url" "${kata_version}")
 	[ -n "$qemu_url" ] || die "failed to get qemu url"
 	qemu_repo="${qemu_url}.git"
 fi
 [ -n "$qemu_repo" ] || die "failed to get qemu repo"
 
-[ -n "$qemu_version" ] || qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version")
+[ -n "$qemu_version" ] || qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version" "${kata_version}")
 if ! (git ls-remote --heads "${qemu_url}" | grep -q "refs/heads/${qemu_version}"); then
-	qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.tag")
+	qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.tag" "${kata_version}")
 fi
 [ -n "$qemu_version" ] || die "failed to get qemu version"
 


### PR DESCRIPTION
These changes introduced for github actions need to be backported so that we can use single latest github action workflow yaml for both 1.9 and 1.10 branches.
Additionally changes have been introduced for nemu, that has been deprecated for 1.10.