### PR TITLE
[WIP] kata-deploy: consider stateless configuration path 

### DIFF
--- a/kata-deploy/kata-deploy.yaml
+++ b/kata-deploy/kata-deploy.yaml
@@ -33,8 +33,12 @@ spec:
         volumeMounts:
         - name: crio-conf
           mountPath: /etc/crio/
+        - name: crio-stateless-conf
+          mountPath: /usr/share/defaults/crio/
         - name: containerd-conf
           mountPath: /etc/containerd/
+        - name: containerd-stateless-conf
+          mountPath: /usr/share/defaults/containerd/
         - name: kata-artifacts
           mountPath: /opt/kata/
         - name: dbus
@@ -47,9 +51,15 @@ spec:
         - name: crio-conf
           hostPath:
             path: /etc/crio/
+        - name: crio-stateless-conf
+          hostPath:
+            path: /usr/share/defaults/crio/
         - name: containerd-conf
           hostPath:
             path: /etc/containerd/
+        - name: containerd-stateless-conf
+          hostPath:
+            path: /usr/share/defaults/containerd/
         - name: kata-artifacts
           hostPath:
             path: /opt/kata/

--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -8,9 +8,24 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+stateless_conf_path="/usr/share/defaults"
+
+crio_stateless_conf_file="${stateless_conf_path}/crio/crio.conf"
 crio_conf_file="/etc/crio/crio.conf"
+# Verify if crio config file exists in /etc. If not,
+# use the stateless config file.
+if [ ! -f "$crio_conf_file" ]; then
+	crio_conf_file="$crio_stateless_conf_file"
+fi
 crio_conf_file_backup="${crio_conf_file}.bak"
+
+containerd_stateless_conf_file="${stateless_conf_path}/containerd/config.toml"
 containerd_conf_file="/etc/containerd/config.toml"
+# Verify if containerd config file exists in /etc. If not,
+# use the stateless config file.
+if [ ! -f "$containerd_conf_file" ]; then
+	containerd_conf_file="$containerd_stateless_conf_file"
+fi
 containerd_conf_file_backup="${containerd_conf_file}.bak"
 
 shims=(


### PR DESCRIPTION

Some distros like Clearlinux may not have the config files
under `/etc` as they use `/usr/share/defaults` as their
stateless configuration path, so we need to take this path
in consideration.
This change will first verify if config file exists in `/etc`
and if not found, it will use the config file in the stateless path. 

Fixes: #833.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>
