### PR TITLE
obs: Check for broken packages

### DIFF
--- a/obs-packaging/wait-obs.sh
+++ b/obs-packaging/wait-obs.sh
@@ -46,6 +46,10 @@ wait_finish_building() {
 			osc pr
 			exit 1
 		fi
+		if echo "${out}" | grep '<details>broken</details>'; then
+			echo "Project ${project} has broken packages"
+			exit 1
+		fi
 		if echo "${out}" | grep 'code="blocked"'; then
 			echo "Project ${project} has blocked packages, waiting"
 			continue


### PR DESCRIPTION
We need to check for broken packages at the obs-wait script.

Fixes #492

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>