### PR TITLE
kata-deploy: Increase the wait timeout for control plane to come up (Backport)

### DIFF
--- a/kata-deploy/action/setup-aks.sh
+++ b/kata-deploy/action/setup-aks.sh
@@ -49,5 +49,5 @@ function setup_aks() {
     kubectl wait --timeout=10m --for=condition=Ready --all nodes
 
     # make sure coredns is up before moving forward:
-    kubectl wait --timeout=5m -n kube-system --for=condition=Available deployment.extensions/coredns
+    kubectl wait --timeout=10m -n kube-system --for=condition=Available deployment.extensions/coredns
 }


### PR DESCRIPTION
Recent runs of setting up aks with github workflows shows that a timeout
of 5m is not always sufficent fot aks control plane to come up.
Increase this from 5m to 10m.

Fixes #839

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>