### PR TITLE
kata-deploy: improve debug message, longer cleanup timeout

### DIFF
--- a/kata-deploy/action/test-kata.sh
+++ b/kata-deploy/action/test-kata.sh
@@ -50,6 +50,8 @@ function waitForLabelRemoval() {
         fi
     done
 
+    echo $(kubectl get pods,nodes --all-namespaces --show-labels)
+
     echo "failed to cleanup"
     return 1
 }
@@ -149,9 +151,9 @@ function test_kata() {
 
     # The cleanup daemonset will run a single time, since it will clear the node-label. Thus, its difficult to
     # check the daemonset's status for completion. instead, let's wait until the kata-runtime labels are removed
-    # from all of the worker nodes. If this doesn't happen in 45 seconds, let's fail
-    timeout=45
-    sleeptime=1
+    # from all of the worker nodes. If this doesn't happen after 2 minutes, let's fail
+    timeout=20
+    sleeptime=6
     waitForLabelRemoval $timeout $sleeptime
 
     kubectl delete -f kata-cleanup.yaml


### PR DESCRIPTION
I am seeing tests fail at times waiting for label cleanup. Let's improve
the error message when this fails, and give the control plane a bit more
time, to improve stability of this test.

Fixes: #846

Signed-off-by: Eric Ernst <eric.ernst@intel.com>