### PR TITLE
release: Checkout right version of kernel patches(backport to 1.9)

### DIFF
--- a/kernel/build-kernel.sh
+++ b/kernel/build-kernel.sh
@@ -269,7 +269,13 @@ get_config_and_patches() {
 	if [ -z "${patches_path}" ]; then
 		info "Clone config and patches"
 		patches_path="${default_patches_dir}"
-		[ -d "${patches_path}" ] || git clone "https://${patches_repo}.git" "${patches_repo_dir}"
+		if [ ! -d "${patches_path}" ]; then
+			tag="${kata_version:-$NEW_VERSION}"
+			git clone "https://${patches_repo}.git" "${patches_repo_dir}"
+			pushd "${patches_repo_dir}" >> /dev/null
+			git checkout $tag
+			popd >> /dev/null
+		fi
 	fi
 }
 


### PR DESCRIPTION
Checkout tag for packaging repo based on env variable NEW_VERSION
or kata_version with kata_version taking precedence.
With this, we checkout to the right version of packaging repo before
applying kernel patches.

Fixes #849

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>