### PR TITLE
Backport fixes for 1.9

### DIFF
--- a/obs-packaging/wait-obs.sh
+++ b/obs-packaging/wait-obs.sh
@@ -50,6 +50,10 @@ wait_finish_building() {
 			echo "Project ${project} has blocked packages, waiting"
 			continue
 		fi
+		if echo "${out}" | grep 'code="unresolvable"'; then
+			echo "Project ${project} has unresolvable packages"
+			exit 1
+		fi
 		if echo "${out}" | grep 'state="building"'; then
 			echo "Project ${project} is still building, waiting"
 			continue

--- a/obs-packaging/wait-obs.sh
+++ b/obs-packaging/wait-obs.sh
@@ -50,14 +50,15 @@ wait_finish_building() {
 			echo "Project ${project} has blocked packages, waiting"
 			continue
 		fi
-		if echo "${out}" | grep 'code="excluded"'; then
-			echo "Project ${project} has excluded packages, waiting"
-			continue
-		fi
 		if echo "${out}" | grep 'state="building"'; then
 			echo "Project ${project} is still building, waiting"
 			continue
 		fi
+		if echo "${out}" | grep 'code="excluded"'; then
+			echo "Project ${project} has excluded packages left, quit waiting"
+			break
+		fi
+
 		echo "No jobs with building status were found"
 		echo "${out}"
 		break

--- a/obs-packaging/wait-obs.sh
+++ b/obs-packaging/wait-obs.sh
@@ -46,6 +46,10 @@ wait_finish_building() {
 			osc pr
 			exit 1
 		fi
+		if echo "${out}" | grep '<details>broken</details>'; then
+			echo "Project ${project} has broken packages"
+			exit 1
+		fi
 		if echo "${out}" | grep 'code="blocked"'; then
 			echo "Project ${project} has blocked packages, waiting"
 			continue


### PR DESCRIPTION
2b0d946 obs: Check for broken packages
e59f03c obs: Failed when we have unresolvable packages
7979c6d obs: Do not wait on excluded packages
