### PR TITLE
image: Change the permissions for image

### DIFF
--- a/obs-packaging/kata-containers-image/debian.postinst
+++ b/obs-packaging/kata-containers-image/debian.postinst
@@ -1,0 +1,13 @@
+#! /bin/sh
+# postinst for kata containers image
+
+set -e
+
+if [ "$1" = configure ]; then
+	if ! getent group kvm >/dev/null; then
+		addgroup --system kvm
+	fi
+	chown -R root:kvm /usr/share/kata-containers
+	chmod -R g+rw /usr/share/kata-containers
+fi
+

--- a/obs-packaging/kata-containers-image/kata-containers-image.spec-template
+++ b/obs-packaging/kata-containers-image/kata-containers-image.spec-template
@@ -15,6 +15,9 @@ Source1:        LICENSE
 %description
 Kata Containers rootfs image
 
+%pre
+getent group kvm >/dev/null || groupadd -r kvm
+
 %prep
 # Patches
 @RPM_APPLY_PATCHES@
@@ -32,6 +35,8 @@ install -m 0400 -p "${image}" ${ImageDir}/
 install -m 0400 -p "${initrd}"  ${ImageDir}/
 ln -s /usr/share/kata-containers/$(basename "${image}") ${ImageDir}/kata-containers.img
 ln -s /usr/share/kata-containers/$(basename "${initrd}")  ${ImageDir}/kata-containers-initrd.img
+chown -R root:kvm ${ImageDir}
+chmod -R g+rw ${ImageDir}
 
 %files
 %if 0%{?suse_version}


### PR DESCRIPTION
Change the group ownership for /usr/share/kata-containers
dir to kvm and allow this group to read, write to the image.
This is to help running rootless containers for users
that are part of the kvm group.

Fixes #855

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>