### PR TITLE
kernel: checkout based on kata_version

### DIFF
--- a/kernel/build-kernel.sh
+++ b/kernel/build-kernel.sh
@@ -272,7 +272,7 @@ get_config_and_patches() {
 		info "Clone config and patches"
 		patches_path="${default_patches_dir}"
 		if [ ! -d "${patches_path}" ]; then
-			tag="${kata_version:-$NEW_VERSION}"
+			tag="${kata_version}"
 			git clone "https://${patches_repo}.git" "${patches_repo_dir}"
 			pushd "${patches_repo_dir}" >> /dev/null
 			git checkout $tag


### PR DESCRIPTION
NEW_VERSION may be unbound, and as a result we fail to run the script.
Let's not rely on user environment in the script.

This may need cleaning if we actually need the ENV variable, though I'm guessing this should be necessary.


Fixes: 857

Signed-off-by: Eric Ernst <eric.ernst@intel.com>