### PR TITLE
kernel: checkout patched based on kata_version

### DIFF
--- a/kernel/build-kernel.sh
+++ b/kernel/build-kernel.sh
@@ -270,10 +270,13 @@ get_config_and_patches() {
 		info "Clone config and patches"
 		patches_path="${default_patches_dir}"
 		if [ ! -d "${patches_path}" ]; then
-			tag="${kata_version:-$NEW_VERSION}"
+			tag="${kata_version}"
 			git clone "https://${patches_repo}.git" "${patches_repo_dir}"
 			pushd "${patches_repo_dir}" >> /dev/null
-			git checkout $tag
+			if [ -n $tag ] ; then
+				info "checking out $tag"
+				git checkout $tag
+			fi
 			popd >> /dev/null
 		fi
 	fi

--- a/release/kata-deploy-binaries.sh
+++ b/release/kata-deploy-binaries.sh
@@ -119,8 +119,8 @@ install_kernel() {
 	kata_version=${1:-$kata_version}
 	pushd "${script_dir}/../"
 	info "build kernel"
-	./kernel/build-kernel.sh setup
-	./kernel/build-kernel.sh build
+	kata_version="${kata_version}" ./kernel/build-kernel.sh setup
+	kata_version="${kata_version}" ./kernel/build-kernel.sh build
 	info "install kernel"
 	kata_version=$kata_version DESTDIR="${destdir}" PREFIX="${prefix}" ./kernel/build-kernel.sh install
 	popd
@@ -134,8 +134,8 @@ install_experimental_kernel() {
 	kata_version=${1:-$kata_version}
 	pushd "${script_dir}/../"
 	info "build experimental kernel"
-	./kernel/build-kernel.sh -e setup
-	./kernel/build-kernel.sh -e build
+	kata_version="${kata_version}" ./kernel/build-kernel.sh -e setup
+	kata_version="${kata_version}" ./kernel/build-kernel.sh -e build
 	info "install experimental kernel"
 	kata_version=$kata_version DESTDIR="${destdir}" PREFIX="${prefix}" ./kernel/build-kernel.sh -e install
 	popd


### PR DESCRIPTION
NEW_VERSION may be unbound whereas kata_version should be defined
following manual release process docs and while using github actions.
Use kata_version instead to checkout correct version of patches.
Check if kata_version is not empty before doing so,
as the release may be triggered for master as well.

Fixes #857

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>