### PR TITLE
obs: Remove fedora 28 obs packages

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -7,7 +7,6 @@
 CentOS_7::CentOS:CentOS-7::standard
 Debian_9::Debian:9.0::standard
 Debian_10::Debian:10::standard
-Fedora_28::Fedora:28::standard
 Fedora_29::Fedora:29::standard
 Fedora_30::Fedora:30::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510

--- a/tests/run_obs_testing.sh
+++ b/tests/run_obs_testing.sh
@@ -16,7 +16,6 @@ DOCKERFILE_PATH="${SCRIPT_PATH}/Dockerfile"
 declare -a OS_DISTRIBUTION=( \
 	'ubuntu:16.04' \
 	'ubuntu:18.04' \
-	'fedora:28' \
 	'fedora:29' \
 	'fedora:30' \
 	'opensuse/leap:15.1' \


### PR DESCRIPTION
Fedora 28 has come to end of life status which makes not possible to
retrieve the repositories while performing an update. This PR removes
this distro with this version so we not longer create and test obs packages
for fedora 28.

Fixes #879

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>