### PR TITLE
obs: Add ubuntu 19.04 testing

### DIFF
--- a/tests/run_obs_testing.sh
+++ b/tests/run_obs_testing.sh
@@ -16,6 +16,7 @@ DOCKERFILE_PATH="${SCRIPT_PATH}/Dockerfile"
 declare -a OS_DISTRIBUTION=( \
 	'ubuntu:16.04' \
 	'ubuntu:18.04' \
+	'ubuntu:19.04' \
 	'fedora:29' \
 	'fedora:30' \
 	'opensuse/leap:15.1' \


### PR DESCRIPTION
Now that we have obs packages for ubuntu 19.04, we should add it in the
testing script.

Fixes #884

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>