### PR TITLE
kata-static: Add sudo while building cloud hypervisor docker image

### DIFF
--- a/static-build/cloud-hypervisor/docker-build/build.sh
+++ b/static-build/cloud-hypervisor/docker-build/build.sh
@@ -11,7 +11,7 @@ set -o pipefail
 script_dir=$(dirname $(readlink -f "$0"))
 docker_image="cloud-hypervisor-builder"
 
-docker build -t "${docker_image}" "${script_dir}"
+sudo docker build -t "${docker_image}" "${script_dir}"
 
 if test -t 1; then
 	USE_TTY="-ti"
@@ -20,7 +20,7 @@ else
 	echo "INFO: not tty build"
 fi
 
-docker run \
+sudo docker run \
 	--rm \
 	-v "$(pwd):/$(pwd)" \
 	-w "$(pwd)" \


### PR DESCRIPTION
If we want to run the build.sh by using a user this is failing by saying
that `failed to dial gRPC: cannot connect to the Docker daemon...
/var/run/docker.sock: connect: permission denied`. This PR fixes that issue.

Fixes #889

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>