### PR TITLE
obs: Remove ubuntu 16.04

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -15,6 +15,5 @@ SLE_12_SP4::SUSE:SLE-12-SP4:GA::standard
 openSUSE_Leap_15.0::openSUSE:Leap:15.0::standard
 openSUSE_Leap_15.1::openSUSE:Leap:15.1::standard
 openSUSE_Tumbleweed::openSUSE:Factory::snapshot
-xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update
 xUbuntu_18.04::Ubuntu:18.04::universe
 xUbuntu_19.04::Ubuntu:19.04::universe


### PR DESCRIPTION
Ubuntu 16.04 has reached eol and we should remove it from the obs generation
distros.

Fixes #892

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>