### PR TITLE
release: tag and branch kata-containers repository

### DIFF
--- a/release/tag_repos.sh
+++ b/release/tag_repos.sh
@@ -69,6 +69,7 @@ info() {
 
 repos=(
 	"agent"
+	"kata-containers"
 	"ksm-throttler"
 	"osbuilder"
 	"packaging"


### PR DESCRIPTION
Now CI depends on this repository, needed to make work stable
branches starting stable-1.10

Fixes: #894

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>