### PR TITLE
release: bump kata-containers repository

### DIFF
--- a/release/update-repository-version.sh
+++ b/release/update-repository-version.sh
@@ -165,6 +165,7 @@ EOT
 
 repos=(
 	"agent"
+	"kata-containers"
 	"ksm-throttler"
 	"osbuilder"
 	"packaging"


### PR DESCRIPTION
kata-containers is now part of the release processs.

Lets update the version for that repository.

Fixes: #905

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>