### PR TITLE
release: use absolute path for kubeconfig

### DIFF
--- a/kata-deploy/action/setup-aks.sh
+++ b/kata-deploy/action/setup-aks.sh
@@ -23,7 +23,7 @@ function die() {
 function destroy_aks() {
     set +x
 
-    export KUBECONFIG="$PWD/_output/$DNS_PREFIX/kubeconfig/kubeconfig.$LOCATION.json"
+    export KUBECONFIG="${PWD}/_output/${DNS_PREFIX}/kubeconfig/kubeconfig.${LOCATION}.json"
 
     az login --service-principal -u "$AZ_APPID" -p "$AZ_PASSWORD" --tenant "$AZ_TENANT_ID"
     az group delete --name "$DNS_PREFIX" --yes --no-wait
@@ -41,7 +41,7 @@ function setup_aks() {
         --location "$LOCATION" --dns-prefix "$DNS_PREFIX" \
         --api-model "$CLUSTER_CONFIG" --force-overwrite
 
-    export KUBECONFIG="_output/$DNS_PREFIX/kubeconfig/kubeconfig.$LOCATION.json"
+    export KUBECONFIG="${PWD}/_output/${DNS_PREFIX}/kubeconfig/kubeconfig.${LOCATION}.json"
 
     # wait for the cluster to be settled:
     kubectl wait --timeout=10m --for=condition=Ready --all nodes


### PR DESCRIPTION
Use absolute path to kubeconfig to allow kubectl use it.

Fixes: #915