### PR TITLE
kata-deploy: improve logic for crio.conf runtime additions

### DIFF
--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -87,7 +87,7 @@ function configure_crio() {
 	local kata_qemu_virtiofs_conf="crio.runtime.runtimes.kata-qemu-virtiofs"
 
 	# add kata-qemu config
-	if grep -q "\[$kata_qemu_conf\]" $crio_conf_file; then
+	if grep -qEe "^\[$kata_qemu_conf\]" $crio_conf_file; then
 		echo "Configuration exists $kata_qemu_conf, overwriting"
 		sed -i "/\[$kata_qemu_conf\]/,+1s#runtime_path.*#runtime_path = \"${kata_qemu_path}\"#" $crio_conf_file
 	else
@@ -100,7 +100,7 @@ EOT
 	fi
 
         # add kata-qemu-virtiofs config
-	if grep -q "\[$kata_qemu_virtiofs_conf\]" $crio_conf_file; then
+	if grep -qEe "^\[$kata_qemu_virtiofs_conf\]" $crio_conf_file; then
 		echo "Configuration exists $kata_qemu_virtiofs_conf, overwriting"
 		sed -i "/\[$kata_qemu_virtiofs_conf\]/,+1s#runtime_path.*#runtime_path = \"${kata_qemu_virtiofs_path}\"#" $crio_conf_file
 	else
@@ -113,7 +113,7 @@ EOT
         fi
 
 	# add kata-fc config
-	if grep -q "\[$kata_fc_conf\]" $crio_conf_file; then
+	if grep -qEe "^\[$kata_fc_conf\]" $crio_conf_file; then
 		echo "Configuration exists for $kata_fc_conf, overwriting"
 		sed -i "/\[$kata_fc_conf\]/,+1s#runtime_path.*#runtime_path = \"${kata_fc_path}\"#" $crio_conf_file
 	else
@@ -126,7 +126,7 @@ EOT
 	fi
 
 	# add kata-clh config
-	if grep -q "\[$kata_clh_conf\]" $crio_conf_file; then
+	if grep -qEe "^\[$kata_clh_conf\]" $crio_conf_file; then
 		echo "Configuration exists $kata_clh_conf, overwriting"
 		sed -i "/\[$kata_clh_conf\]/,+1s#runtime_path.*#runtime_path = \"${kata_clh_path}\"#" $crio_conf_file
 	else


### PR DESCRIPTION
Now crio.conf has some kata entries in by default, but commented
out and without the runtime_path elements to them, our deploy
script gets a little confused and fails to add the kata-qemu
elements to the config.

This is because the grep spots the commented out lines, and tries
to, unsuccessfully, update the matching runtime_path elements, that
don't actually exist.

Improve this by matching only uncommented config lines, so now the
script sees that the runtime is not really configured already, and
instead of trying to edit/update it, will place a entry at the
end of the file.

Fixes: #928

Signed-off-by: Graham Whaley <graham.whaley@intel.com>