### PR TITLE
pkgs: fix kernel build

### DIFF
--- a/obs-packaging/linux-container/_service-template
+++ b/obs-packaging/linux-container/_service-template
@@ -3,7 +3,7 @@
   <service name="download_url">
     <param name="protocol">https</param>
     <param name="host">cdn.kernel.org</param>
-    <param name="path">/pub/linux/kernel/v4.x/linux-@VERSION@.tar.xz</param>
+    <param name="path">/pub/linux/kernel/v5.x/linux-@VERSION@.tar.xz</param>
   </service>
   <service name="verify_file">
      <param name="file">_service:download_url:linux-@VERSION@.tar.xz</param>

--- a/obs-packaging/linux-container/debian.rules
+++ b/obs-packaging/linux-container/debian.rules
@@ -24,7 +24,7 @@ override_dh_auto_build:
 	rm -f .config
 	find $(KERNEL_CONFIGS) -name "$(KERNEL_ARCH)_kata_kvm_*" -exec cp {} .config \;
 	if [ ! -f .config ]; then \
-		scripts/kconfig/merge_config.sh -r -n $(KERNEL_FRAG_COMMON_DIR)/* $(KERNEL_FRAG_ARCH_DIR)/* ; \
+		scripts/kconfig/merge_config.sh -r -n $(KERNEL_FRAG_COMMON_DIR)/*.conf $(KERNEL_FRAG_ARCH_DIR)/* ; \
 		if [ ! -f .config ]; then \
 			echo "ERROR: cannot find the kernel config file for the $(KERNEL_ARCH) architecture"; \
 			exit 1; \

--- a/obs-packaging/linux-container/kata-linux-container.spec-template
+++ b/obs-packaging/linux-container/kata-linux-container.spec-template
@@ -11,7 +11,7 @@ License:        GPL-2.0
 Summary:        The Linux kernel optimized for running inside a container
 Group:          System/Kernel
 Url:            http://www.kernel.org/
-Source0:        https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-@VERSION@.tar.xz
+Source0:        https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-@VERSION@.tar.xz
 Source1:        kata-kernel-configs.tar.gz
 Source2:        kata-multiarch.sh
 
@@ -84,7 +84,7 @@ BuildKernel() {
         # Use fragments to generate the .config
         frag_dir="kata-kernel-configs/fragments"
         err_msg="not in final"
-        r="$(KCONFIG_CONFIG=.config ARCH=${kernelArch} scripts/kconfig/merge_config.sh -r -n ${frag_dir}/common/* ${frag_dir}/${kernelArch}/* | grep "${err_msg}")" || true
+        r="$(KCONFIG_CONFIG=.config ARCH=${kernelArch} scripts/kconfig/merge_config.sh -r -n ${frag_dir}/common/*.conf ${frag_dir}/${kernelArch}/* | grep "${err_msg}")" || true
         [ -z "${r}" ] || (echo "ERROR: ${r}"; exit 1)
     fi
     [ -f .config ] || (echo "ERROR: cannot find the kernel config file for the ${kernelArch} architecture"; exit 1)

--- a/obs-packaging/linux-container/kata-linux-container.spec-template
+++ b/obs-packaging/linux-container/kata-linux-container.spec-template
@@ -83,9 +83,7 @@ BuildKernel() {
     if [ ! -f .config ]; then
         # Use fragments to generate the .config
         frag_dir="kata-kernel-configs/fragments"
-        err_msg="not in final"
-        r="$(KCONFIG_CONFIG=.config ARCH=${kernelArch} scripts/kconfig/merge_config.sh -r -n ${frag_dir}/common/*.conf ${frag_dir}/${kernelArch}/* | grep "${err_msg}")" || true
-        [ -z "${r}" ] || (echo "ERROR: ${r}"; exit 1)
+        KCONFIG_CONFIG=.config ARCH=${kernelArch} scripts/kconfig/merge_config.sh -r -n ${frag_dir}/common/*.conf ${frag_dir}/${kernelArch}/*
     fi
     [ -f .config ] || (echo "ERROR: cannot find the kernel config file for the ${kernelArch} architecture"; exit 1)
 


### PR DESCRIPTION
Kernel build for packages got broken after upgrade, this add needed
changes to build again.

Fixes #924

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>