### PR TITLE
release: tag the kata-containers/kata-contaners repo last

### DIFF
--- a/release/tag_repos.sh
+++ b/release/tag_repos.sh
@@ -69,7 +69,6 @@ info() {
 
 repos=(
 	"agent"
-	"kata-containers"
 	"ksm-throttler"
 	"osbuilder"
 	"packaging"
@@ -77,6 +76,7 @@ repos=(
 	"runtime"
 	"shim"
 	"tests"
+	"kata-containers"
 )
 
 


### PR DESCRIPTION
This repo triggers the github action to create release tarballs.
It looks for release tags in other repos. So tag this repo
last to make sure tags have been created on other repos.

Fixes #947

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>