### PR TITLE
Backport: lib: yq: explode anchors to get real value of image values

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -57,7 +57,7 @@ get_from_kata_deps() {
 		echo "Download from ${yaml_url}" >&2
 		curl --silent -o "${versions_file}" "$yaml_url"
 	fi
-	result=$("${GOPATH}/bin/yq" read "$versions_file" "$dependency")
+	result=$("${GOPATH}/bin/yq" read -X "$versions_file" "$dependency")
 	[ "$result" = "null" ] && result=""
 	echo "$result"
 }


### PR DESCRIPTION
yq is not exploding anchors anymore and requiere an extra flag.

Add flag to fix CI.

Fixes: #934

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>