### PR TITLE
test: Test for kata-containers packages on Fedora 31

### DIFF
--- a/tests/Dockerfile/FedoraDockerfile.in
+++ b/tests/Dockerfile/FedoraDockerfile.in
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Usage: FROM [image name]
+FROM @OS_DISTRIBUTION@
+
+ENV TESTS_REPO="github.com/kata-containers/tests"
+
+RUN @UPDATE@
+
+RUN @DEPENDENCIES@
+
+ENV PATH=$PATH:/usr/local/go/bin
+ENV GOPATH=/home/go
+ENV TESTS_REPOSITORY_PATH="${GOPATH}/src/${TESTS_REPO}"
+ENV AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine
+
+# Install packages
+RUN sudo dnf -y install kata-proxy kata-ksm-throttler kata-osbuilder kata-runtime kata-shim
+RUN sudo mkdir "${GOPATH}"
+RUN sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+RUN sudo dnf makecache
+RUN sudo dnf -y install docker-ce
+RUN go get -d "${TESTS_REPO}"
+RUN cd "${TESTS_REPOSITORY_PATH}" && .ci/install_kata_image.sh
+RUN cd "${TESTS_REPOSITORY_PATH}" && .ci/install_kata_kernel.sh
+RUN kata-runtime kata-env
+
+CMD ["/bin/bash"]

--- a/tests/run_packages_testing.sh
+++ b/tests/run_packages_testing.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+http_proxy="${http_proxy:-}"
+https_proxy="${https_proxy:-}"
+DOCKERFILE_PATH="${SCRIPT_PATH}/Dockerfile"
+OS_DISTRIBUTION="${OS_DISTRIBUTION:-fedora:31}"
+
+install_packages() {
+	echo "Test distribution packages for ${OS_DISTRIBUTION}"
+	run_test
+	remove_image_and_dockerfile
+}
+
+run_test() {
+	generate_dockerfile
+	build_dockerfile
+}
+
+generate_dockerfile() {
+	UPDATE="dnf -y update"
+	DEPENDENCIES="dnf install -y curl git make sudo golang dnf-plugin-config-manager"
+
+	echo "Building dockerfile for ${OS_DISTRIBUTION}"
+	sed \
+		-e "s|@OS_DISTRIBUTION@|${OS_DISTRIBUTION}|g" \
+		-e "s|@UPDATE@|${UPDATE}|g" \
+		-e "s|@DEPENDENCIES@|${DEPENDENCIES}|g" \
+		"${DOCKERFILE_PATH}/FedoraDockerfile.in" > "${DOCKERFILE_PATH}"/Dockerfile
+}
+
+build_dockerfile() {
+	pushd "${DOCKERFILE_PATH}"
+		sudo docker build \
+			--build-arg http_proxy="${http_proxy}" \
+			--build-arg https_proxy="${https_proxy}" \
+			--tag "packaging-kata-test-${OS_DISTRIBUTION}" .
+	popd
+}
+
+remove_image_and_dockerfile() {
+	echo "Removing image test-${OS_DISTRIBUTION}"
+	sudo docker rmi "packaging-kata-test-${OS_DISTRIBUTION}"
+
+	echo "Removing dockerfile"
+	sudo rm -f "${DOCKERFILE_PATH}/Dockerfile"
+}
+
+function main() {
+	echo "Run packaging testing"
+	install_packages
+}
+
+main "$@"


### PR DESCRIPTION
This will test the kata-containers packages that are available on
Fedora 31 to see that they are working properly.

Fixes #951

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>