### PR TITLE
obs: Remove obs packages and testing for ubuntu 19.04 and fedora 29

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -7,7 +7,6 @@
 CentOS_7::CentOS:CentOS-7::standard
 Debian_9::Debian:9.0::standard
 Debian_10::Debian:10::standard
-Fedora_29::Fedora:29::standard
 Fedora_30::Fedora:30::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510
 #RHEL_7::RedHat:RHEL-7::standard
@@ -17,4 +16,3 @@ openSUSE_Leap_15.1::openSUSE:Leap:15.1::standard
 openSUSE_Tumbleweed::openSUSE:Factory::snapshot
 xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update
 xUbuntu_18.04::Ubuntu:18.04::universe
-xUbuntu_19.04::Ubuntu:19.04::universe

--- a/tests/run_obs_testing.sh
+++ b/tests/run_obs_testing.sh
@@ -16,8 +16,6 @@ DOCKERFILE_PATH="${SCRIPT_PATH}/Dockerfile"
 declare -a OS_DISTRIBUTION=( \
 	'ubuntu:16.04' \
 	'ubuntu:18.04' \
-	'ubuntu:19.04' \
-	'fedora:29' \
 	'fedora:30' \
 	'opensuse/leap:15.1' \
 	'debian:9' \


### PR DESCRIPTION
Now that ubuntu 19.04 and fedora 29 has come EOL, we should remove the generation of
the obs generation and testing for ubuntu 19.04.

Fixes #953

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>