### PR TITLE
scripts/qemu: enable libpmem

### DIFF
--- a/obs-packaging/qemu-vanilla/debian.rules-template
+++ b/obs-packaging/qemu-vanilla/debian.rules-template
@@ -6,7 +6,7 @@ export LANG=C
 
 override_dh_auto_configure:
 	chmod a+x "../SOURCES/configure-hypervisor.sh"
-	eval "../SOURCES/configure-hypervisor.sh" "qemu-vanilla" | xargs ./configure --prefix=/usr
+	eval "../SOURCES/configure-hypervisor.sh" "qemu-vanilla" | sed -e 's/--enable-libpmem//g' | xargs ./configure --prefix=/usr
 override_dh_auto_build:
 	make
 
@@ -24,4 +24,3 @@ override_dh_auto_test:
 
 override_dh_auto_clean:
 	echo "Skip auto clean"
-

--- a/obs-packaging/qemu-vanilla/qemu-vanilla.spec-template
+++ b/obs-packaging/qemu-vanilla/qemu-vanilla.spec-template
@@ -47,6 +47,7 @@ BuildRequires : python
 BuildRequires : python-devel
 BuildRequires : zlib-devel
 BuildRequires : pkgconfig(pixman-1)
+BuildRequires : libpmem-devel
 
 # Patches
 @RPM_PATCH_LIST@

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -330,10 +330,6 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-linux-aio)
 
 	if [[ "${qemu_version_major}" -ge 4 || ( "${qemu_version_major}" -eq 3  &&  "${qemu_version_minor}" -ge 1 ) ]]; then
-		# Disable libpmem, vNVDIMM backend (aka rootfs image) shouldn't be modifed
-		# by the guest
-		qemu_options+=(security:--disable-libpmem)
-
 		# Disable graphics
 		qemu_options+=(size:--disable-virglrenderer)
 
@@ -396,6 +392,11 @@ generate_qemu_options() {
 		fi
 		# Enable libc malloc_trim() for memory optimization.
 		qemu_options+=(speed:--enable-malloc-trim)
+
+		# According to QEMU's nvdimm documentation: When 'pmem' is 'on' and QEMU is
+		# built with libpmem support, QEMU will take necessary operations to guarantee
+		# the persistence of its own writes to the vNVDIMM backend.
+		qemu_options+=(functionality:--enable-libpmem)
 	fi
 
 	#---------------------------------------------------------------------

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -338,6 +338,7 @@ parts:
       - curl
       - libcapstone-dev
       - bc
+      - libpmem-dev
     override-build: |
       kata_version=$(cat ${SNAPCRAFT_STAGE}/kata_version)
       yq=$(realpath ../../yq/build/yq)

--- a/static-build/qemu-virtiofs/Dockerfile
+++ b/static-build/qemu-virtiofs/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get install -y \
 	    libglib2.0-dev git \
 	    libltdl-dev \
 	    libpixman-1-dev \
+	    libpmem-dev \
 	    libseccomp-dev \
 	    libtool \
 	    patch \

--- a/static-build/qemu/Dockerfile
+++ b/static-build/qemu/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get install -y \
 	    libglib2.0-dev git \
 	    libltdl-dev \
 	    libpixman-1-dev \
+	    libpmem-dev \
 	    libtool \
 	    pkg-config \
 	    pkg-config \


### PR DESCRIPTION
Enable libpmem to support PMEM when running under Kubernetes.

see https://github.com/kata-containers/runtime/issues/2262

According to QEMU's nvdimm documentation: When 'pmem' is 'on' and QEMU is
built with libpmem support, QEMU will take necessary operations to guarantee
the persistence of its own writes to the vNVDIMM backend.

fixes #958

Signed-off-by: Julio Montes <julio.montes@intel.com>