### PR TITLE
ci: Provide source directory path for script execution

### DIFF
--- a/Jenkinsfiles/release_pieline/Jenkinsfile
+++ b/Jenkinsfiles/release_pieline/Jenkinsfile
@@ -25,16 +25,14 @@ pipeline {
     stage('Bump repos') {
       agent { label 'ubuntu-lts-latest-azure' }
       steps {
-        sh '''
-        git clone https://github.com/kata-containers/packaging.git
-        cd packaging
-        '''
+        sh 'git clone https://github.com/kata-containers/packaging.git'
         withCredentials([string(credentialsId: 'katabuilder-git-bump', variable: 'GITHUB_TOKEN')]) {
-          sh '''
-          cd packaging
-          ./Jenkinsfiles/release_pieline/git_credential_cache.sh
-          ./Jenkinsfiles/release_pieline/bump.sh "${NEW_VERSION}" "${BRANCH}"
-          '''
+          dir("${WORKSPACE}/packaging/Jenkinsfiles/release_pipeline/") {
+            sh '''
+                ./git_credential_cache.sh
+                ./bump.sh "${NEW_VERSION}" "${BRANCH}"
+               '''
+          }
         }
       }
     }


### PR DESCRIPTION
1. For the git clone operation, `sh` step in a single line would suffice.
2. Provide directory context using `dir`, this avoids having to provide the complete path to each and every script, that are in that folder, while executing.

Signed-off-by: Ramanathan Muthaiah <rus.cahimb@gmail.com>