### PR TITLE
obs: Update obs packages for ppc64le

### DIFF
--- a/obs-packaging/distros_ppc64le
+++ b/obs-packaging/distros_ppc64le
@@ -5,8 +5,7 @@
 #   name::project::repository
 #
 CentOS_7::CentOS:CentOS-7::standard
-Fedora_28::Fedora:28::standard
-Fedora_29::Fedora:29::standard
+Fedora_30::Fedora:30::standard
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 openSUSE_Leap_15.0::openSUSE:Leap:15.0:Ports::ports
 xUbuntu_16.04::Ubuntu:16.04:Ports::universe,update


### PR DESCRIPTION
Fedora versions 28 and 29 has come EOL, we should update the generation
of obs packages but now for Fedora 30.

Fixes #963

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>