### PR TITLE
scripts: enable libpmem only for x86_64

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -387,16 +387,16 @@ generate_qemu_options() {
 		# for that architecture
 		if [ "$arch" == x86_64 ]; then
 			qemu_options+=(speed:--enable-avx2)
+			# According to QEMU's nvdimm documentation: When 'pmem' is 'on' and QEMU is
+			# built with libpmem support, QEMU will take necessary operations to guarantee
+			# the persistence of its own writes to the vNVDIMM backend.
+			qemu_options+=(functionality:--enable-libpmem)
 		else
 			qemu_options+=(speed:--disable-avx2)
+			qemu_options+=(functionality:--disable-libpmem)
 		fi
 		# Enable libc malloc_trim() for memory optimization.
 		qemu_options+=(speed:--enable-malloc-trim)
-
-		# According to QEMU's nvdimm documentation: When 'pmem' is 'on' and QEMU is
-		# built with libpmem support, QEMU will take necessary operations to guarantee
-		# the persistence of its own writes to the vNVDIMM backend.
-		qemu_options+=(functionality:--enable-libpmem)
 	fi
 
 	#---------------------------------------------------------------------

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -338,7 +338,6 @@ parts:
       - curl
       - libcapstone-dev
       - bc
-      - libpmem-dev
     override-build: |
       kata_version=$(cat ${SNAPCRAFT_STAGE}/kata_version)
       yq=$(realpath ../../yq/build/yq)
@@ -381,6 +380,9 @@ parts:
           --strip 1 \
           --input "$patch"
       done
+
+      # Only x86_64 supports libpmem
+      [ "$(uname -m)" = "x86_64" ] && sudo apt-get install -y libpmem-dev
 
       chmod +x ${SNAPCRAFT_STAGE}/scripts/configure-hypervisor.sh
       # static build


### PR DESCRIPTION
Not all architectures have support for libpmem.
Enable libpmem only for x86_64

fixes #965

Signed-off-by: Julio Montes <julio.montes@intel.com>