### PR TITLE
pod : optimization Some debian package manager tweaks

### DIFF
--- a/.ci/azure/pipelines/obs-packaging-ci.yml
+++ b/.ci/azure/pipelines/obs-packaging-ci.yml
@@ -21,7 +21,7 @@ jobs:
 
   - bash: |
       sudo apt-get update -y -qq
-      sudo apt-get install -y git
+      sudo apt-get --no-install-recommends install -y git
       git config --global user.email "azure-pipeline@kata.io"
       git config --global user.name "azure-pipeline"
       .ci/packaging/setup.sh

--- a/.ci/azure/pipelines/release.yml
+++ b/.ci/azure/pipelines/release.yml
@@ -21,7 +21,7 @@ jobs:
 
   - bash: |
       sudo apt-get update -y -qq
-      sudo apt-get install -y git
+      sudo apt-get --no-install-recommends install -y git
       git config --global user.email "azure-pipeline@kata.io"
       git config --global user.name "azure-pipeline"
     displayName: 'Setup'

--- a/.ci/azure/pipelines/release.yml
+++ b/.ci/azure/pipelines/release.yml
@@ -21,7 +21,7 @@ jobs:
 
   - bash: |
       sudo apt-get update -y -qq
-      sudo apt-get --no-install-recommends install -y git
+      sudo apt-get --no-install-recommends install -y apt-utils ca-certificates git
       git config --global user.email "azure-pipeline@kata.io"
       git config --global user.name "azure-pipeline"
     displayName: 'Setup'

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -37,7 +37,7 @@ if [ "$SNAP_CI" == "true" ] && [ "$ID" == "ubuntu" ]; then
 	export INSTALL_KATA="no"
 
 	echo "Install snap dependencies"
-	sudo apt-get install -y snapd snapcraft make
+	sudo apt-get --no-install-recommends install -y snapd snapcraft make
 
 	echo "Building snap image"
 	make snap

--- a/Jenkinsfiles/release_pieline/bump.sh
+++ b/Jenkinsfiles/release_pieline/bump.sh
@@ -47,12 +47,12 @@ install_go() {
 
 install_docker() {
 	echo "Installing docker"
-	sudo -E apt-get -y install apt-transport-https ca-certificates software-properties-common
+	sudo -E apt-get --no-install-recommends install -y apt-transport-https ca-certificates software-properties-common
 	curl -sL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 	arch=$(dpkg --print-architecture)
 	sudo -E add-apt-repository "deb [arch=${arch}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 	sudo -E apt-get update
-	sudo -E apt-get -y install docker-ce
+	sudo -E apt-get --no-install-recommends install -y docker-ce
 }
 
 setup_git() {

--- a/Jenkinsfiles/release_pieline/bump.sh
+++ b/Jenkinsfiles/release_pieline/bump.sh
@@ -47,7 +47,7 @@ install_go() {
 
 install_docker() {
 	echo "Installing docker"
-	sudo -E apt-get --no-install-recommends install -y apt-transport-https ca-certificates software-properties-common
+	sudo -E apt-get --no-install-recommends install -y apt-transport-https apt-utils ca-certificates software-properties-common
 	curl -sL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 	arch=$(dpkg --print-architecture)
 	sudo -E add-apt-repository "deb [arch=${arch}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"

--- a/ccloudvm/kata-docker-xenial.yaml
+++ b/ccloudvm/kata-docker-xenial.yaml
@@ -34,7 +34,7 @@ runcmd:
  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
  - {{proxyVars .}} curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
  - sudo -E apt-get update
- - sudo -E apt-get --no-install-recommends install -y kata-runtime
+ - sudo -E apt-get --no-install-recommends install -y apt-utils ca-certificates kata-runtime
  - {{endTaskCheck .}}
 
 ...

--- a/ccloudvm/kata-docker-xenial.yaml
+++ b/ccloudvm/kata-docker-xenial.yaml
@@ -34,7 +34,7 @@ runcmd:
  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/ /' > /etc/apt/sources.list.d/kata-containers.list"
  - {{proxyVars .}} curl -sL  http://download.opensuse.org/repositories/home:/katacontainers:/releases:/${ARCH}:/master/xUbuntu_$(lsb_release -rs)/Release.key | sudo apt-key add -
  - sudo -E apt-get update
- - sudo -E apt-get -y install kata-runtime
+ - sudo -E apt-get --no-install-recommends install -y kata-runtime
  - {{endTaskCheck .}}
 
 ...

--- a/snap/README.md
+++ b/snap/README.md
@@ -17,7 +17,7 @@ Kata Containers can be installed in any Linux distribution that supports
 [snapd](https://docs.snapcraft.io/installing-snapd). For this example, we
 assume Ubuntu as your base distro.
 ```sh
-$ sudo apt-get --no-install-recommends install -y snapd snapcraft
+$ sudo apt-get --no-install-recommends install -y apt-utils ca-certificates snapd snapcraft
 ```
 
 ## Install snap

--- a/snap/README.md
+++ b/snap/README.md
@@ -17,7 +17,7 @@ Kata Containers can be installed in any Linux distribution that supports
 [snapd](https://docs.snapcraft.io/installing-snapd). For this example, we
 assume Ubuntu as your base distro.
 ```sh
-$ sudo apt-get install -y snapd snapcraft
+$ sudo apt-get --no-install-recommends install -y snapd snapcraft
 ```
 
 ## Install snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -196,7 +196,7 @@ parts:
       # install podman
       sudo add-apt-repository -y ppa:projectatomic/ppa
       sudo apt-get update
-      sudo apt-get --no-install-recommends install -y podman
+      sudo apt-get --no-install-recommends install -y apt-utils ca-certificates podman
 
       # Build and install cni plugings
       echo "Retrieve CNI plugins repository"
@@ -382,7 +382,7 @@ parts:
       done
 
       # Only x86_64 supports libpmem
-      [ "$(uname -m)" = "x86_64" ] && sudo apt-get --no-install-recommends install -y libpmem-dev
+      [ "$(uname -m)" = "x86_64" ] && sudo apt-get --no-install-recommends install -y apt-utils ca-certificates libpmem-dev
 
       chmod +x ${SNAPCRAFT_STAGE}/scripts/configure-hypervisor.sh
       # static build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -196,7 +196,7 @@ parts:
       # install podman
       sudo add-apt-repository -y ppa:projectatomic/ppa
       sudo apt-get update
-      sudo apt-get -y install podman
+      sudo apt-get --no-install-recommends install -y podman
 
       # Build and install cni plugings
       echo "Retrieve CNI plugins repository"
@@ -382,7 +382,7 @@ parts:
       done
 
       # Only x86_64 supports libpmem
-      [ "$(uname -m)" = "x86_64" ] && sudo apt-get install -y libpmem-dev
+      [ "$(uname -m)" = "x86_64" ] && sudo apt-get --no-install-recommends install -y libpmem-dev
 
       chmod +x ${SNAPCRAFT_STAGE}/scripts/configure-hypervisor.sh
       # static build

--- a/static-build/cloud-hypervisor/docker-build/Dockerfile
+++ b/static-build/cloud-hypervisor/docker-build/Dockerfile
@@ -6,7 +6,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get install -yq build-essential mtools libssl-dev pkg-config curl git
+RUN apt-get --no-install-recommends install -yq build-essential mtools libssl-dev pkg-config curl git
 RUN nohup curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/static-build/cloud-hypervisor/docker-build/Dockerfile
+++ b/static-build/cloud-hypervisor/docker-build/Dockerfile
@@ -6,7 +6,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get --no-install-recommends install -yq build-essential mtools libssl-dev pkg-config curl git
+RUN apt-get --no-install-recommends install -yq apt-utils ca-certificates build-essential mtools libssl-dev pkg-config curl git
 RUN nohup curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/static-build/qemu-virtiofs/Dockerfile
+++ b/static-build/qemu-virtiofs/Dockerfile
@@ -9,10 +9,12 @@ ARG PREFIX
 WORKDIR /root/qemu-virtiofs
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get --no-install-recommends install -y \
+	    apt-utils \
 	    autoconf \
 	    automake \
 	    bc \
 	    bison \
+	    ca-certificates \
 	    cpio \
 	    flex \
 	    gawk \

--- a/static-build/qemu-virtiofs/Dockerfile
+++ b/static-build/qemu-virtiofs/Dockerfile
@@ -8,7 +8,7 @@ ARG PREFIX
 
 WORKDIR /root/qemu-virtiofs
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
 	    autoconf \
 	    automake \
 	    bc \

--- a/static-build/qemu/Dockerfile
+++ b/static-build/qemu/Dockerfile
@@ -9,10 +9,12 @@ ARG PREFIX
 WORKDIR /root/qemu
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get --no-install-recommends install -y \
+	    apt-utils \
 	    autoconf \
 	    automake \
 	    bc \
 	    bison \
+	    ca-certificates \
 	    cpio \
 	    flex \
 	    gawk \

--- a/static-build/qemu/Dockerfile
+++ b/static-build/qemu/Dockerfile
@@ -8,7 +8,7 @@ ARG PREFIX
 
 WORKDIR /root/qemu
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
 	    autoconf \
 	    automake \
 	    bc \

--- a/static-build/scripts/kata-configure-docker.sh
+++ b/static-build/scripts/kata-configure-docker.sh
@@ -122,7 +122,7 @@ setup()
 
 	case "$distro" in
 		centos|rhel) $chronic sudo -E yum -y install "$pkg" ;;
-		debian|ubuntu) $chronic sudo -E apt -y install "$pkg" ;;
+		debian|ubuntu) $chronic sudo -E apt-get --no-install-recommends install -y "$pkg" ;;
 		fedora) $chronic sudo -E dnf -y install "$pkg" ;;
 		opensuse|sles) $chronic sudo -E zypper -y install "$pkg" ;;
 		*) die "do not know how to install command $pkg' for distro '$distro'" ;;

--- a/tests/run_obs_testing.sh
+++ b/tests/run_obs_testing.sh
@@ -50,7 +50,7 @@ generate_dockerfile() {
 			;;
 		debian|ubuntu)
 			UPDATE="apt-get -y update"
-			DEPENDENCIES="apt-get install -y curl git gnupg2 lsb-release sudo"
+			DEPENDENCIES="apt-get --no-install-recommends install -y curl git gnupg2 lsb-release sudo"
 			;;
 		fedora)
 			UPDATE="dnf -y update"

--- a/tests/run_obs_testing.sh
+++ b/tests/run_obs_testing.sh
@@ -50,7 +50,7 @@ generate_dockerfile() {
 			;;
 		debian|ubuntu)
 			UPDATE="apt-get -y update"
-			DEPENDENCIES="apt-get --no-install-recommends install -y curl git gnupg2 lsb-release sudo"
+			DEPENDENCIES="apt-get --no-install-recommends install -y apt-utils ca-certificates curl git gnupg2 lsb-release sudo"
 			;;
 		fedora)
 			UPDATE="dnf -y update"


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Fixes #970

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>