### PR TITLE
actions: change trigger phrase for kata-deploy action

### DIFF
--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -9,7 +9,7 @@ jobs:
         uses: kata-containers/slash-command-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          command: "test"
+          command: "test-kata-deploy"
           reaction: "true"
           reaction-type: "eyes"
           allow-edits: "false"
@@ -17,7 +17,6 @@ jobs:
       - name: verify command arg is kata-deploy
         run: |
            echo "The command was '${{ steps.command.outputs.command-name }}' with arguments '${{ steps.command.outputs.command-arguments }}'"
-           [[ ${{ steps.command.outputs.command-arguments}} == "kata-deploy" ]]
   create-and-test-container:
     needs: check_comments
     runs-on: ubuntu-latest


### PR DESCRIPTION
Let's change the kata-deploy github action trigger from:
  '/test kata-deploy'
to
 '/test-kata-deploy'

which will hopefully reduce the number of false triggers caused when
we issue the 'normal' CI runs that are triggered by other
'/test xxxx' phrases.

Fixes: #971

Signed-off-by: Graham Whaley <graham.whaley@intel.com>