### PR TITLE
obs: Remove OpenSUSE Leap 15.0 from obs generation

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -11,7 +11,6 @@ Fedora_30::Fedora:30::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510
 #RHEL_7::RedHat:RHEL-7::standard
 SLE_12_SP4::SUSE:SLE-12-SP4:GA::standard
-openSUSE_Leap_15.0::openSUSE:Leap:15.0::standard
 openSUSE_Leap_15.1::openSUSE:Leap:15.1::standard
 openSUSE_Tumbleweed::openSUSE:Factory::snapshot
 xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update


### PR DESCRIPTION
OpenSUSE Leap 15.0 has reached EOL, this PR removes the obs generation.

Fixes #980

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>