### PR TITLE
obs: Update SLES version for packaging

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -10,7 +10,7 @@ Debian_10::Debian:10::standard
 Fedora_30::Fedora:30::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510
 #RHEL_7::RedHat:RHEL-7::standard
-SLE_12_SP4::SUSE:SLE-12-SP4:GA::standard
+SLE_15_SP1::SUSE:SLE-15-SP1:GA::standard
 openSUSE_Leap_15.1::openSUSE:Leap:15.1::standard
 openSUSE_Tumbleweed::openSUSE:Factory::snapshot
 xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update

--- a/obs-packaging/kata-containers-image/kata-containers-image.spec-template
+++ b/obs-packaging/kata-containers-image/kata-containers-image.spec-template
@@ -1,7 +1,7 @@
 Name:           kata-containers-image
 Version:        @VERSION@
 Release:        @RELEASE@
-License:        Artistic-1.0 BSD-3-Clause BSD-3-Clause-Kata BSD-4-Clause-UC GFDL-1.3 GPL-2.0 GPL-2.0+ GPL-3.0 GPL-3.0+ LGPL-2.0 LGPL-2.0+ LGPL-2.1 LGPL-3.0+ MIT MPL-2.0 Public-Domain 
+License:        Artistic-1.0 and BSD-3-Clause and BSD-4-Clause-UC and GFDL-1.3 and GPL-2.0 and GPL-2.0+ and GPL-3.0 and GPL-3.0+ and LGPL-2.0 and LGPL-2.0+ and LGPL-2.1 and LGPL-3.0+ and MIT and MPL-2.0
 Summary:        Kata Containers Image
 Url:            https://github.com/kata-containers/osbuilder
 Group:          image

--- a/obs-packaging/qemu-vanilla/qemu-vanilla.spec-template
+++ b/obs-packaging/qemu-vanilla/qemu-vanilla.spec-template
@@ -9,7 +9,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 
 Summary  : OpenBIOS development utilities
 Group    : Development/Tools
-License  : BSD-2-Clause BSD-3-Clause GPL-2.0 GPL-2.0+ LGPL-2.0+ LGPL-2.1
+License  : BSD-2-Clause and BSD-3-Clause and GPL-2.0 and GPL-2.0+ and LGPL-2.0+ and LGPL-2.1
 
 Requires: qemu-vanilla-bin
 Requires: qemu-vanilla-data
@@ -58,7 +58,7 @@ QEMU is a generic and open source machine & userspace emulator and
 virtualizer.
 
 %package bin
-Summary: bin components for the qemu-vanilla package.
+Summary: Bin components for the qemu-vanilla package
 Group: Binaries
 Requires: qemu-vanilla-data
 
@@ -67,7 +67,7 @@ bin components for the qemu-vanilla package.
 
 
 %package data
-Summary: data components for the qemu-vanilla package.
+Summary: Data components for the qemu-vanilla package
 Group: Data
 
 %description data


### PR DESCRIPTION
Currently for our CI, we have SLES 15 SP1, this PR updates the current obs
version to match with our current testing.

Fixes #983

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>