### PR TITLE
kata-deploy: fix k3s containerd check

### DIFF
--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -33,7 +33,7 @@ function print_usage() {
 
 function get_container_runtime() {
 
-	local runtime=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}' | awk -F '[:]' '{print $1}')
+	local runtime=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}')
 	if [ "$?" -ne 0 ]; then
                 die "invalid node name"
 	fi
@@ -44,7 +44,7 @@ function get_container_runtime() {
 			echo "k3s"
 		fi
 	else
-		echo "$runtime"
+		echo "$runtime" | awk -F '[:]' '{print $1}'
 	fi
 }
 


### PR DESCRIPTION
fixes #996

The default k3s `containerRuntimeVersion` takes the form of ```containerd://1.3.3-k3s2```.
The `awk` was stripping away the `k3s` portion before checking if it was a k3s containerd.