### PR TITLE
tests: Remove performing updates in Fedora dockerfile

### DIFF
--- a/tests/Dockerfile/FedoraDockerfile.in
+++ b/tests/Dockerfile/FedoraDockerfile.in
@@ -7,8 +7,6 @@ FROM @OS_DISTRIBUTION@
 
 ENV TESTS_REPO="github.com/kata-containers/tests"
 
-RUN @UPDATE@
-
 RUN @DEPENDENCIES@
 
 ENV PATH=$PATH:/usr/local/go/bin

--- a/tests/run_packages_testing.sh
+++ b/tests/run_packages_testing.sh
@@ -32,7 +32,6 @@ generate_dockerfile() {
 	echo "Building dockerfile for ${OS_DISTRIBUTION}"
 	sed \
 		-e "s|@OS_DISTRIBUTION@|${OS_DISTRIBUTION}|g" \
-		-e "s|@UPDATE@|${UPDATE}|g" \
 		-e "s|@DEPENDENCIES@|${DEPENDENCIES}|g" \
 		"${DOCKERFILE_PATH}/FedoraDockerfile.in" > "${DOCKERFILE_PATH}"/Dockerfile
 }


### PR DESCRIPTION
For obs and running the packages testing in Fedora, we need to remove
the performing of doing an update as it is hit by
https://github.com/kata-containers/runtime/issues/2580. This is needed
to unblock the errors in the testing.

Fixes #1001

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>