### PR TITLE
scripts: Disable pie for qemu when static building

### DIFF
--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -432,7 +432,7 @@ generate_qemu_options() {
 	fi
 
 	# aarch64 need to explictly set --enable-pie
-	if [ "${arch}" = "aarch64" ]; then
+	if [ -z "${static}" ] && [ "${arch}" = "aarch64" ]; then
 		qemu_options+=(arch:"--enable-pie")
 	fi
 


### PR DESCRIPTION
--enable-pie is not compatible with --static option for qemu building.
Without this patch, it will report a configure error during static building:

ERROR: static and pie are mutually incompatible

Fixes: #982

Signed-off-by: Jia He <justin.he@arm.com>