### PR TITLE
obs: let patch set in order before apply them

### DIFF
--- a/obs-packaging/scripts/pkglib.sh
+++ b/obs-packaging/scripts/pkglib.sh
@@ -375,7 +375,7 @@ function find_patches() {
 	export RPM_APPLY_PATCHES="#Apply patches"$'\n'
 	[ ! -d patches ] && info "No patches found" && return
 	local patches
-	patches=$(find patches/ -type f -name '*.patch' -exec basename {} \;)
+	patches=$(find patches/ -type f -name '*.patch' -exec basename {} \; | sort -t- -k1,1n)
 	n="1"
 	rm -f debian.series
 	for p in ${patches}; do


### PR DESCRIPTION
obs ci for linuxcontainer will fail when apply patch set which have
dependency within. so patch set should be made in order before feed
to apply.

Fixes: #1015

Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@grahamwhaley @jodh-intel 