### PR TITLE
backport: stable-1.9: yq: remove `-X` flag

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -57,7 +57,7 @@ get_from_kata_deps() {
 		echo "Download from ${yaml_url}" >&2
 		curl --silent -o "${versions_file}" "$yaml_url"
 	fi
-	result=$("${GOPATH}/bin/yq" read -X "$versions_file" "$dependency")
+	result=$("${GOPATH}/bin/yq" read "$versions_file" "$dependency")
 	[ "$result" = "null" ] && result=""
 	echo "$result"
 }


### PR DESCRIPTION
stable-1.9 branch uses old version of yq that doesn't support
the `-X` flag, so we need to remove it.

Fixes: #1011.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>