### PR TITLE
backport: tools: use yq 2.3.0 for stable-1.9

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -14,18 +14,19 @@ install_yq() {
 	[ -x "${GOPATH}/bin/yq" ] && return
 
 	get_kata_arch
+	local goos="$(uname -s)"
 	goarch=$("${kata_arch_sh}" -g)
 
 	mkdir -p "${GOPATH}/bin"
 
-	# Workaround to get latest release from github (to not use github token).
-	# Get the redirection to latest release on github.
-	yq_latest_url=$(curl -Ls -o /dev/null -w %{url_effective} "https://${yq_pkg}/releases/latest")
-	# The redirected url should include the latest release version
-	# https://github.com/mikefarah/yq/releases/tag/<VERSION-HERE>
-	yq_version=$(basename "${yq_latest_url}")
 
-	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_linux_${goarch}"
+	# Stick to a specific version. Same used in
+	# runtime and osbuilder repos.
+	yq_version=2.3.0
+
+	## NOTE: ${var,,} => gives lowercase value of var
+	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos,,}_${goarch}"
+
 	curl -o "${yq_path}" -L "${yq_url}"
 	chmod +x "${yq_path}"
 }


### PR DESCRIPTION
We need to use the same yq version in stable-1.10 across all
the repositories.

In the future, we should check the installed version of yq and
use (or not) the corresponding flag.

Fixes: #1022.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>
(cherry picked from commit 6fe4d781fd452b2e8c8470f31390d5b1bfde7eef)