### PR TITLE
CI: enable Travis static checks

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2018,2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+export tests_repo_dir="$GOPATH/src/$tests_repo"
+
+clone_tests_repo()
+{
+	# KATA_CI_NO_NETWORK is (has to be) ignored if there is
+	# no existing clone.
+	if [ -d "$tests_repo_dir" -a -n "$KATA_CI_NO_NETWORK" ]
+	then
+		return
+	fi
+
+	go get -d -u "$tests_repo" || true
+	if [ -n "${TRAVIS_BRANCH:-}" ]; then
+		( cd "${tests_repo_dir}" && git checkout "${TRAVIS_BRANCH}" )
+	fi
+}
+
+run_static_checks()
+{
+	clone_tests_repo
+	bash "$tests_repo_dir/.ci/static-checks.sh"  "github.com/kata-containers/packaging"
+}
+
+run_go_test()
+{
+	clone_tests_repo
+	bash "$tests_repo_dir/.ci/go-test.sh"
+}

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018,2020 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-#
 
-set -o errexit
-set -o nounset
-set -o pipefail
+set -e
 
-# This script should run any static analysis check
-# It is called by the CI setup
-true
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+# Run static checks
+run_static_checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+#
+# Copyright 2017 HyperHQ Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+sudo: required
+dist: bionic
+
+os:
+  - linux
+  - linux-ppc64le
+
+language: go
+go_import_path: github.com/kata-containers/packaging
+
+env:
+  - target_branch=$TRAVIS_BRANCH
+
+before_script:
+  - ".ci/setup.sh"
+
+script:
+  - bash .ci/static-checks.sh github.com/kata-containers/packaging

--- a/cmd/kata-pkgsync/cli/main.go
+++ b/cmd/kata-pkgsync/cli/main.go
@@ -258,7 +258,7 @@ func main() {
 		logrus.WithFields(logrus.Fields{
 			"OBS project":       proj.Name,
 			"Packagecloud Repo": pc.Repo,
-		}).Infof("Sucessfully transferred %d files", totalXferred)
+		}).Infof("Successfully transferred %d files", totalXferred)
 	}
 
 	if !*pcDelete {


### PR DESCRIPTION
Set up the config file and .ci subdir files to enable Travis to perform static
checks on PRs to this repo.