### PR TITLE
backport 1.10 fixes

### DIFF
--- a/release/tag_repos.sh
+++ b/release/tag_repos.sh
@@ -69,6 +69,7 @@ info() {
 
 repos=(
 	"agent"
+	"documentation"
 	"ksm-throttler"
 	"osbuilder"
 	"packaging"

--- a/release/update-repository-version.sh
+++ b/release/update-repository-version.sh
@@ -165,6 +165,7 @@ EOT
 
 repos=(
 	"agent"
+	"kata-containers"
 	"ksm-throttler"
 	"osbuilder"
 	"packaging"


### PR DESCRIPTION
0763f2a release: bump kata-containers repository
bf0baf9 release: Tag and fork documentation repo as part of release
