### PR TITLE
Detect v2 schema and use correct long form of cri plugin

### DIFF
--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -151,7 +151,11 @@ function configure_containerd_runtime() {
 		runtime+="-$1"
 		configuration+="-$1"
 	fi
-	local runtime_table="plugins.cri.containerd.runtimes.$runtime"
+	local pluginid=cri
+	if grep -q "version = 2\>" $containerd_conf_file; then
+		pluginid=\"io.containerd.grpc.v1.cri\"
+	fi
+	local runtime_table="plugins.${pluginid}.containerd.runtimes.$runtime"
 	local runtime_type="io.containerd.$runtime.v2"
 	local options_table="$runtime_table.options"
 	local config_path="/opt/kata/share/defaults/kata-containers/$configuration.toml"


### PR DESCRIPTION
CRI has a v2 schema that seems to be the default in a lot of
containerd installations. It uses a "long" form for the plugin
id in the TOML config file.

Fixes #881. I couldn't find any tests for this script, and I 
don't really have time to learn how to build the whole project,
but I did test this change with my config.toml and it worked.