### PR TITLE
pkgs: Remove debian 10

### DIFF
--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -6,7 +6,8 @@
 #
 CentOS_7::CentOS:CentOS-7::standard
 Debian_9::Debian:9.0::standard
-Debian_10::Debian:10::standard
+# Qemu vanilla is broken see https://github.com/kata-containers/packaging/issues/1051
+#Debian_10::Debian:10::standard
 Fedora_30::Fedora:30::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510
 #RHEL_7::RedHat:RHEL-7::standard


### PR DESCRIPTION
Debian 10 has been broken for a while but CI started
to detected recently.

Remove package until find a way to build it.

Fixes: #1052

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>