### PR TITLE
static-build: build qemu on ubuntu 20.04

### DIFF
--- a/static-build/qemu.blacklist
+++ b/static-build/qemu.blacklist
@@ -23,7 +23,6 @@ qemu_black_list=(
 */share/*/openbios-sparc32
 */share/*/openbios-sparc64
 */share/*/palcode-clipper
-*/share/*/ppc_rom.bin
 */share/*/pxe-*
 */share/*/QEMU,*
 */share/*/qemu_vga.ndrv

--- a/static-build/qemu/Dockerfile
+++ b/static-build/qemu/Dockerfile
@@ -1,4 +1,4 @@
-from ubuntu:18.04
+from ubuntu:20.04
 
 ARG QEMU_REPO
 # commit/tag/branch
@@ -19,6 +19,7 @@ RUN apt-get --no-install-recommends install -y \
 	    flex \
 	    gawk \
 	    libaudit-dev \
+	    libblkid-dev \
 	    libcap-dev \
 	    libcap-ng-dev \
 	    libdw-dev \
@@ -33,6 +34,7 @@ RUN apt-get --no-install-recommends install -y \
 	    libpmem-dev \
 	    libselinux1-dev \
 	    libtool \
+	    make \
 	    pkg-config \
 	    pkg-config \
 	    python \


### PR DESCRIPTION
Update ubuntu version to 20.04, due to the following linkage errors
is not possible to build QEMU 5 on ubuntu 18.04.

```
libmount.a(libmount_la-fs.o): In function `__mnt_fs_set_source_ptr':
(.text+0x9b1): undefined reference to `blkid_parse_tag_string'
libmount.a(libmount_la-tab.o): In function `mnt_table_find_source':
(.text+0x1dbf): undefined reference to `blkid_parse_tag_string'
libmount.a(libmount_la-utils.o): In function `mnt_tag_is_valid':
(.text+0x618): undefined reference to `blkid_parse_tag_string'
libmount.a(libmount_la-cache.o): In function `mnt_free_cache':
(.text+0x834): undefined reference to `blkid_put_cache'
libmount.a(libmount_la-cache.o): In function `mnt_cache_read_tags':
(.text+0xa24): undefined reference to `blkid_new_probe_from_filename'
(.text+0xa3d): undefined reference to `blkid_probe_enable_superblocks'
(.text+0xa4a): undefined reference to `blkid_probe_set_superblocks_flags'
(.text+0xa57): undefined reference to `blkid_probe_enable_partitions'
(.text+0xa64): undefined reference to `blkid_probe_set_partitions_flags'
(.text+0xa6c): undefined reference to `blkid_do_safeprobe'
(.text+0xb32): undefined reference to `blkid_free_probe'
(.text+0xb7c): undefined reference to `blkid_free_probe'
(.text+0xba0): undefined reference to `blkid_probe_lookup_value'
libmount.a(libmount_la-cache.o): In function `mnt_get_fstype':
(.text+0xef0): undefined reference to `blkid_new_probe_from_filename'
(.text+0xf09): undefined reference to `blkid_probe_enable_superblocks'
(.text+0xf16): undefined reference to `blkid_probe_set_superblocks_flags'
(.text+0xf1e): undefined reference to `blkid_do_safeprobe'
(.text+0xf4a): undefined reference to `blkid_free_probe'
(.text+0xf68): undefined reference to `blkid_probe_lookup_value'
libmount.a(libmount_la-cache.o): In function `mnt_resolve_tag':
(.text+0x130b): undefined reference to `blkid_evaluate_tag'
```

fixes #1060

Signed-off-by: Julio Montes <julio.montes@intel.com>