### PR TITLE
kata-deploy: add ACRN runtime to Docker configuration

### DIFF
--- a/kata-deploy/scripts/kata-deploy-docker.sh
+++ b/kata-deploy/scripts/kata-deploy-docker.sh
@@ -51,6 +51,10 @@ function configure_docker() {
      "kata-clh": {
       "path": "/opt/kata/bin/kata-runtime",
       "runtimeArgs": [ "--kata-config", "/opt/kata/share/defaults/kata-containers/configuration-clh.toml" ]
+    },
+     "kata-acrn": {
+      "path": "/opt/kata/bin/kata-runtime",
+      "runtimeArgs": [ "--kata-config", "/opt/kata/share/defaults/kata-containers/configuration-acrn.toml" ]
     }
   }
 }


### PR DESCRIPTION
Add an ACRN runtime ('kata-acrn') to the Docker configuration (daemon.json)

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>