### PR TITLE
snap: build QEMU 4.1.1 not 5.0.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -359,7 +359,8 @@ parts:
         ;;
 
         *)
-          branch="$(curl -sSL ${versions_url} | ${yq} r - assets.hypervisor.qemu.tag)"
+          # Issue: https://github.com/kata-containers/packaging/issues/1092
+          branch="v4.1.1" #"$(curl -sSL ${versions_url} | ${yq} r - assets.hypervisor.qemu.tag)"
           url="$(curl -sSL ${versions_url} | ${yq} r - assets.hypervisor.qemu.url)"
           patch_dir="${SNAPCRAFT_STAGE}/qemu/patches/$(echo ${branch} | cut -d. -f1-2 | tr -d v).x"
           commit=""


### PR DESCRIPTION
The static libraries needed to build QEMU 5.0.0 are not available in
Ubuntu 18.04 and due to some bugs in the azure ubuntu 20.04 image, it's not
possible to build QEMU 5 statically

fixes #1090

Signed-off-by: Julio Montes <julio.montes@intel.com>