### PR TITLE
kata-deploy: Add containerd configuration to support kata annotations.

### DIFF
--- a/kata-deploy/scripts/kata-deploy.sh
+++ b/kata-deploy/scripts/kata-deploy.sh
@@ -171,6 +171,7 @@ function configure_containerd_runtime() {
 [$runtime_table]
   runtime_type = "${runtime_type}"
   privileged_without_host_devices = true
+  pod_annotations = ["io.katacontainers.*"]
 EOT
 	fi
 


### PR DESCRIPTION
In case of containerd, not all annotations are passed down to the OCI
layer. We need to configure "pod_annotations" field for a runtime class.
This field is a list of annotations that can be passed by Kata as OCI
annotations. Add this as default configuration with kata-deploy.

Fixes #1093

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>