### PR TITLE
snap: build snap using Ubuntu 20.04

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   advantages of VMs
 confinement: classic
 adopt-info: metadata
+base: core20
 
 parts:
   metadata:
@@ -173,11 +174,13 @@ parts:
     after: [go]
     plugin: nil
     build-packages:
+      - docker.io
       - cpio
       - git
       - iptables
       - software-properties-common
       - uidmap
+      - gnupg2
     override-build: |
       kata_version=$(cat ${SNAPCRAFT_STAGE}/kata_version)
       yq=$(realpath ../../yq/build/yq)
@@ -193,27 +196,23 @@ parts:
       export GOROOT=$(realpath ../../go/build)
       export PATH="${GOROOT}/bin:${PATH}"
 
-      # install podman
-      sudo add-apt-repository -y ppa:projectatomic/ppa
-      sudo apt-get update
-      sudo apt-get --no-install-recommends install -y apt-utils ca-certificates podman
-
-      # Build and install cni plugings
-      echo "Retrieve CNI plugins repository"
-      go get -d ${cni_plugings_repo} || true
-      cd $GOPATH/src/${cni_plugings_repo}
-
-      echo "Build CNI plugins"
-      ./build_linux.sh
-
-      echo "Install CNI binaries"
-      cni_bin_path="/opt/cni"
-      sudo mkdir -p ${cni_bin_path}
-      sudo cp -a bin ${cni_bin_path}
+      if [ -n "$http_proxy" ]; then
+        echo "Setting proxy $http_proxy"
+        sudo -E systemctl set-environment http_proxy=$http_proxy || true
+        sudo -E systemctl set-environment https_proxy=$https_proxy || true
+      fi
 
       # Copy yq binary. It's used in the container
       mkdir -p "${GOPATH}/bin/"
       cp -a "${yq}" "${GOPATH}/bin/"
+
+      echo "Unmasking docker service"
+      sudo -E systemctl unmask docker.service || true
+      sudo -E systemctl unmask docker.socket || true
+      echo "Adding $USER into docker group"
+      sudo -E gpasswd -a $USER docker
+      echo "Starting docker"
+      sudo -E systemctl start docker || true
 
       # download source
       git clone -b ${kata_version} https://github.com/kata-containers/${pkg_name} ${pkg_gopath}
@@ -222,8 +221,8 @@ parts:
       # build image
       export AGENT_VERSION=${kata_version}
       export AGENT_INIT=yes
-      export USE_PODMAN=1
       export DEBUG=1
+      export USE_DOCKER=1
       case "$(uname -m)" in
         aarch64|ppc64le|s390x)
           sudo -E PATH=$PATH make initrd DISTRO=alpine
@@ -359,8 +358,7 @@ parts:
         ;;
 
         *)
-          # Issue: https://github.com/kata-containers/packaging/issues/1092
-          branch="v4.1.1" #"$(curl -sSL ${versions_url} | ${yq} r - assets.hypervisor.qemu.tag)"
+          branch="$(curl -sSL ${versions_url} | ${yq} r - assets.hypervisor.qemu.tag)"
           url="$(curl -sSL ${versions_url} | ${yq} r - assets.hypervisor.qemu.url)"
           patch_dir="${SNAPCRAFT_STAGE}/qemu/patches/$(echo ${branch} | cut -d. -f1-2 | tr -d v).x"
           commit=""


### PR DESCRIPTION
Ubuntu 20.04 is required to build statically QEMU 5.

fixes #1107

Signed-off-by: Julio Montes <julio.montes@intel.com>