### PR TITLE
qemu: don't disable seccomp - needed for virtiofsd

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,7 @@ This directory contains useful packaging scripts.
 ## `configure-hypervisor.sh`
 
 This script generates the official set of QEMU-based hypervisor build
-configuration options. All repositories that need to build a hypervisor
+configuration options. All repositories that need to build the QEMU VMM
 from source **MUST** use this script to ensure the hypervisor is built
 in a known way since using a different set of options can impact many
 areas including performance, memory footprint and security.

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -262,7 +262,6 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-snappy)
 
 	# Disable unused security options
-	qemu_options+=(security:--disable-seccomp)
 	qemu_options+=(security:--disable-tpm)
 
 	# Disable userspace network access ("-net user")


### PR DESCRIPTION
Rather than sed'ing the output of configure-hypervisor.sh, let's go
ahead and update to no longer disable seccomp. Seccomp is necessary for
utilizing virtiofsd, which is supported in QEMU

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>