### PR TITLE
Stop building for distros that already support kata

### DIFF
--- a/obs-packaging/distros_ppc64le
+++ b/obs-packaging/distros_ppc64le
@@ -5,6 +5,5 @@
 #   name::project::repository
 #
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
-openSUSE_Leap_15.0::openSUSE:Leap:15.0:Ports::ports
 xUbuntu_16.04::Ubuntu:16.04:Ports::universe,update
 xUbuntu_18.04::Ubuntu:18.04:Ports::universe

--- a/obs-packaging/distros_ppc64le
+++ b/obs-packaging/distros_ppc64le
@@ -4,6 +4,5 @@
 #
 #   name::project::repository
 #
-SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 xUbuntu_16.04::Ubuntu:16.04:Ports::universe,update
 xUbuntu_18.04::Ubuntu:18.04:Ports::universe

--- a/obs-packaging/distros_ppc64le
+++ b/obs-packaging/distros_ppc64le
@@ -4,7 +4,6 @@
 #
 #   name::project::repository
 #
-CentOS_7::CentOS:CentOS-7::standard
 Fedora_30::Fedora:30::standard
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 openSUSE_Leap_15.0::openSUSE:Leap:15.0:Ports::ports

--- a/obs-packaging/distros_ppc64le
+++ b/obs-packaging/distros_ppc64le
@@ -4,7 +4,6 @@
 #
 #   name::project::repository
 #
-Fedora_30::Fedora:30::standard
 SLE_12_SP3::SUSE:SLE-12-SP3:GA::standard
 openSUSE_Leap_15.0::openSUSE:Leap:15.0:Ports::ports
 xUbuntu_16.04::Ubuntu:16.04:Ports::universe,update

--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -7,8 +7,6 @@
 Debian_9::Debian:9.0::standard
 # Qemu vanilla is broken see https://github.com/kata-containers/packaging/issues/1051
 #Debian_10::Debian:10::standard
-# FIXME: https://github.com/kata-containers/packaging/issues/510
-#RHEL_7::RedHat:RHEL-7::standard
 xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update
 xUbuntu_18.04::Ubuntu:18.04::universe
 xUbuntu_20.04::Ubuntu:20.04::universe

--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -9,7 +9,6 @@ Debian_9::Debian:9.0::standard
 #Debian_10::Debian:10::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510
 #RHEL_7::RedHat:RHEL-7::standard
-SLE_15_SP1::SUSE:SLE-15-SP1:GA::standard
 xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update
 xUbuntu_18.04::Ubuntu:18.04::universe
 xUbuntu_20.04::Ubuntu:20.04::universe

--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -7,7 +7,6 @@
 Debian_9::Debian:9.0::standard
 # Qemu vanilla is broken see https://github.com/kata-containers/packaging/issues/1051
 #Debian_10::Debian:10::standard
-Fedora_30::Fedora:30::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510
 #RHEL_7::RedHat:RHEL-7::standard
 SLE_15_SP1::SUSE:SLE-15-SP1:GA::standard

--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -10,8 +10,6 @@ Debian_9::Debian:9.0::standard
 # FIXME: https://github.com/kata-containers/packaging/issues/510
 #RHEL_7::RedHat:RHEL-7::standard
 SLE_15_SP1::SUSE:SLE-15-SP1:GA::standard
-openSUSE_Leap_15.1::openSUSE:Leap:15.1::standard
-openSUSE_Tumbleweed::openSUSE:Factory::snapshot
 xUbuntu_16.04::Ubuntu:16.04::universe,universe-update,update
 xUbuntu_18.04::Ubuntu:18.04::universe
 xUbuntu_20.04::Ubuntu:20.04::universe

--- a/obs-packaging/distros_x86_64
+++ b/obs-packaging/distros_x86_64
@@ -4,8 +4,6 @@
 #
 #   name::project::repository
 #
-CentOS_7::CentOS:CentOS-7::standard
-CentOS_8::CentOS:CentOS-8::standard
 Debian_9::Debian:9.0::standard
 # Qemu vanilla is broken see https://github.com/kata-containers/packaging/issues/1051
 #Debian_10::Debian:10::standard


### PR DESCRIPTION
We can rely on distros packages for SUSE, openSUSE, Fedora, and CentOS.

For RHEL, users are better relying on CentOS packages as a workaround instead of relying on the community version of the packages.