### PR TITLE
clh: Pull static binary when possible.

### DIFF
--- a/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/static-build/cloud-hypervisor/build-static-clh.sh
@@ -36,6 +36,15 @@ repo_dir="${repo_dir//.git}"
 cd "${repo_dir}"
 git fetch || true
 git checkout "${cloud_hypervisor_version}"
-"${script_dir}/docker-build/build.sh"
-rm -f cloud-hypervisor
-cp ./target/release/cloud-hypervisor .
+static_url="${cloud_hypervisor_repo}"
+static_url="${static_url//.git}"
+static_url="${static_url}/releases/download/${cloud_hypervisor_version}/cloud-hypervisor-static"
+info "Try to pull from ${static_url}"
+if curl --fail -L "${static_url}" -o "cloud-hypervisor";then
+	info "pull hypervisor from release"
+else
+	info "build from source"
+	"${script_dir}/docker-build/build.sh"
+	rm -f cloud-hypervisor
+	cp ./target/release/cloud-hypervisor .
+fi


### PR DESCRIPTION
Cloud hypervisor publish its own static binaries on releases.  Lets try
to pull from it when possible, else build from source, this is useful
when for some reason clh build is broken.

Fixes: #1140

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>