### PR TITLE
snap: move snap CI to github actions

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,15 @@
+name: snap CI
+on: ["pull_request"]
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Install Snapcraft
+        uses: samuelmeuli/action-snapcraft@v1
+
+      - name: Build snap
+        run: |
+          snapcraft -d snap --destructive-mode


### PR DESCRIPTION
Move snap CI to github actions, since it needs ubuntu 20.04 to build
and there is no such image in the current jenkins-azure CI system

fixes #1092

Signed-off-by: Julio Montes <julio.montes@intel.com>