### PR TITLE
qemu: Tweak configuration script for qemu 5.1

### DIFF
--- a/qemu/patches/5.1.x/0001-9p-removing-coroutines-of-9p-to-increase-the-I-O-per.patch
+++ b/qemu/patches/5.1.x/0001-9p-removing-coroutines-of-9p-to-increase-the-I-O-per.patch
@@ -1,0 +1,98 @@
+From 3de89ce9fb5eda46f7cefd70e9090cb7cd7ec803 Mon Sep 17 00:00:00 2001
+From: Yang Zhong <yang.zhong@intel.com>
+Date: Wed, 28 Mar 2018 20:14:53 +0800
+Subject: [PATCH 1/2] 9p: removing coroutines of 9p to increase the I/O
+ performance
+
+This is a quick workaround, need to be fixed.
+
+Signed-off-by: Chao Peng <chao.p.peng@linux.intel.com>
+---
+ hw/9pfs/9p.c   | 12 +++++-------
+ hw/9pfs/9p.h   |  6 +++---
+ hw/9pfs/coth.h |  3 +++
+ 3 files changed, 11 insertions(+), 10 deletions(-)
+
+diff --git a/hw/9pfs/9p.c b/hw/9pfs/9p.c
+index 9e046f7acb..11c8ee08d9 100644
+--- a/hw/9pfs/9p.c
++++ b/hw/9pfs/9p.c
+@@ -1082,10 +1082,7 @@ static void coroutine_fn pdu_complete(V9fsPDU *pdu, ssize_t len)
+ out_notify:
+     pdu->s->transport->push_and_notify(pdu);
+ 
+-    /* Now wakeup anybody waiting in flush for this request */
+-    if (!qemu_co_queue_next(&pdu->complete)) {
+-        pdu_free(pdu);
+-    }
++    pdu_free(pdu);
+ }
+ 
+ static mode_t v9mode_to_mode(uint32_t mode, V9fsString *extension)
+@@ -3997,7 +3994,7 @@ static inline bool is_read_only_op(V9fsPDU *pdu)
+ 
+ void pdu_submit(V9fsPDU *pdu, P9MsgHeader *hdr)
+ {
+-    Coroutine *co;
++//    Coroutine *co;
+     CoroutineEntry *handler;
+     V9fsState *s = pdu->s;
+ 
+@@ -4015,8 +4012,9 @@ void pdu_submit(V9fsPDU *pdu, P9MsgHeader *hdr)
+     }
+ 
+     qemu_co_queue_init(&pdu->complete);
+-    co = qemu_coroutine_create(handler, pdu);
+-    qemu_coroutine_enter(co);
++    handler(pdu);
++    //co = qemu_coroutine_create(handler, pdu);
++    //qemu_coroutine_enter(co);
+ }
+ 
+ /* Returns 0 on success, 1 on failure. */
+diff --git a/hw/9pfs/9p.h b/hw/9pfs/9p.h
+index b8f72a3bd9..d16bf9d05e 100644
+--- a/hw/9pfs/9p.h
++++ b/hw/9pfs/9p.h
+@@ -391,21 +391,21 @@ extern int total_open_fd;
+ static inline void v9fs_path_write_lock(V9fsState *s)
+ {
+     if (s->ctx.export_flags & V9FS_PATHNAME_FSCONTEXT) {
+-        qemu_co_rwlock_wrlock(&s->rename_lock);
++    //    qemu_co_rwlock_wrlock(&s->rename_lock);
+     }
+ }
+ 
+ static inline void v9fs_path_read_lock(V9fsState *s)
+ {
+     if (s->ctx.export_flags & V9FS_PATHNAME_FSCONTEXT) {
+-        qemu_co_rwlock_rdlock(&s->rename_lock);
++     //   qemu_co_rwlock_rdlock(&s->rename_lock);
+     }
+ }
+ 
+ static inline void v9fs_path_unlock(V9fsState *s)
+ {
+     if (s->ctx.export_flags & V9FS_PATHNAME_FSCONTEXT) {
+-        qemu_co_rwlock_unlock(&s->rename_lock);
++     //   qemu_co_rwlock_unlock(&s->rename_lock);
+     }
+ }
+ 
+diff --git a/hw/9pfs/coth.h b/hw/9pfs/coth.h
+index c2cdc7a9ea..0fe971d1f5 100644
+--- a/hw/9pfs/coth.h
++++ b/hw/9pfs/coth.h
+@@ -46,6 +46,9 @@
+         qemu_coroutine_yield();                                         \
+     } while (0)
+ 
++#undef v9fs_co_run_in_worker
++#define v9fs_co_run_in_worker(code_block) do {code_block} while(0);
++
+ void co_run_in_worker_bh(void *);
+ int coroutine_fn v9fs_co_readlink(V9fsPDU *, V9fsPath *, V9fsString *);
+ int coroutine_fn v9fs_co_readdir(V9fsPDU *, V9fsFidState *, struct dirent **);
+-- 
+2.21.0
+

--- a/qemu/patches/5.1.x/0002-memory-backend-file-nvdimm-support-read-only-files-a.patch
+++ b/qemu/patches/5.1.x/0002-memory-backend-file-nvdimm-support-read-only-files-a.patch
@@ -1,0 +1,45 @@
+From 3a6e5e157f355b3c42b6c2a0c85b4acaba849ac3 Mon Sep 17 00:00:00 2001
+From: Julio Montes <julio.montes@intel.com>
+Date: Mon, 8 Jul 2019 21:19:36 +0000
+Subject: [PATCH 2/2] memory-backend-file/nvdimm: support read-only files as
+ memory-backends
+
+Currently it is not possible to use a file that is part of a read-only
+filesystem as memory backend for nvdimm devices, even if the file itself
+is not modified in the guest. Same goes for files that do not have write access.
+In order to improve the security of Virtual Machines that share
+and do not modify the memory-backend-file, QEMU should support
+read-only memory-backends.
+
+Use case:
+* Kata Containers use a memory-backed-file as read-only rootfs, and this
+  file is used to start all the virtual machines in the node.
+  It would be really bad if somehow a malicious container modified it.
+
+Signed-off-by: Julio Montes <julio.montes@intel.com>
+Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
+Message-Id: <20190708211936.8037-1-julio.montes@intel.com>
+---
+ exec.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/exec.c b/exec.c
+index 2874bb5088..ba2fff234b 100644
+--- a/exec.c
++++ b/exec.c
+@@ -1781,6 +1781,12 @@ static int file_ram_open(const char *path,
+                 break;
+             }
+             g_free(filename);
++        } else if (errno == EROFS || errno == EACCES) {
++            fd = open(path, O_RDONLY);
++            if (fd >= 0) {
++                /* @path names an existing read-only file, use it */
++                break;
++            }
+         }
+         if (errno != EEXIST && errno != EINTR) {
+             error_setg_errno(errp, errno,
+-- 
+2.21.0
+

--- a/qemu/patches/5.1.x/0003-virtio-skip-legacy-support-check-on-machine-types-le.patch
+++ b/qemu/patches/5.1.x/0003-virtio-skip-legacy-support-check-on-machine-types-le.patch
@@ -1,0 +1,143 @@
+From d55f518248f263bb8d0852f98e47102ea09d4f89 Mon Sep 17 00:00:00 2001
+From: Stefano Garzarella <sgarzare@redhat.com>
+Date: Mon, 21 Sep 2020 14:25:03 +0200
+Subject: [PATCH 1/4] virtio: skip legacy support check on machine types less
+ than 5.1
+
+Commit 9b3a35ec82 ("virtio: verify that legacy support is not accidentally
+on") added a check that returns an error if legacy support is on, but the
+device does not support legacy.
+
+Unfortunately some devices were wrongly declared legacy capable even if
+they were not (e.g vhost-vsock).
+
+To avoid migration issues, we add a virtio-device property
+(x-disable-legacy-check) to skip the legacy error, printing a warning
+instead, for machine types < 5.1.
+
+Cc: qemu-stable@nongnu.org
+Fixes: 9b3a35ec82 ("virtio: verify that legacy support is not accidentally on")
+Suggested-by: Dr. David Alan Gilbert <dgilbert@redhat.com>
+Suggested-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Cornelia Huck <cohuck@redhat.com>
+Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>
+Message-Id: <20200921122506.82515-2-sgarzare@redhat.com>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
+---
+ hw/core/machine.c          |  1 +
+ hw/s390x/virtio-ccw.c      | 15 ++++++++++++---
+ hw/virtio/virtio-pci.c     | 14 ++++++++++++--
+ hw/virtio/virtio.c         |  7 +++++++
+ include/hw/virtio/virtio.h |  2 ++
+ 5 files changed, 34 insertions(+), 5 deletions(-)
+
+diff --git a/hw/core/machine.c b/hw/core/machine.c
+index 9b02fb2..d7f4a0d 100644
+--- a/hw/core/machine.c
++++ b/hw/core/machine.c
+@@ -44,6 +44,7 @@ GlobalProperty hw_compat_5_0[] = {
+     { "vmport", "x-signal-unsupported-cmd", "off" },
+     { "vmport", "x-report-vmx-type", "off" },
+     { "vmport", "x-cmds-v2", "off" },
++    { "virtio-device", "x-disable-legacy-check", "true" },
+ };
+ const size_t hw_compat_5_0_len = G_N_ELEMENTS(hw_compat_5_0);
+
+diff --git a/hw/s390x/virtio-ccw.c b/hw/s390x/virtio-ccw.c
+index 8d140dc..4582e94 100644
+--- a/hw/s390x/virtio-ccw.c
++++ b/hw/s390x/virtio-ccw.c
+@@ -1122,9 +1122,18 @@ static void virtio_ccw_device_plugged(DeviceState *d, Error **errp)
+     }
+
+     if (!virtio_ccw_rev_max(dev) && !virtio_legacy_allowed(vdev)) {
+-        error_setg(errp, "Invalid value of property max_rev "
+-                   "(is %d expected >= 1)", virtio_ccw_rev_max(dev));
+-        return;
++        /*
++         * To avoid migration issues, we allow legacy mode when legacy
++         * check is disabled in the old machine types (< 5.1).
++         */
++        if (virtio_legacy_check_disabled(vdev)) {
++            warn_report("device requires revision >= 1, but for backward "
++                        "compatibility max_revision=0 is allowed");
++        } else {
++            error_setg(errp, "Invalid value of property max_rev "
++                       "(is %d expected >= 1)", virtio_ccw_rev_max(dev));
++            return;
++        }
+     }
+
+     if (virtio_get_num_queues(vdev) > VIRTIO_QUEUE_MAX) {
+diff --git a/hw/virtio/virtio-pci.c b/hw/virtio/virtio-pci.c
+index 02790e3..36524a5 100644
+--- a/hw/virtio/virtio-pci.c
++++ b/hw/virtio/virtio-pci.c
+@@ -1597,8 +1597,18 @@ static void virtio_pci_device_plugged(DeviceState *d, Error **errp)
+
+     if (legacy) {
+         if (!virtio_legacy_allowed(vdev)) {
+-            error_setg(errp, "device is modern-only, use disable-legacy=on");
+-            return;
++            /*
++             * To avoid migration issues, we allow legacy mode when legacy
++             * check is disabled in the old machine types (< 5.1).
++             */
++            if (virtio_legacy_check_disabled(vdev)) {
++                warn_report("device is modern-only, but for backward "
++                            "compatibility legacy is allowed");
++            } else {
++                error_setg(errp,
++                           "device is modern-only, use disable-legacy=on");
++                return;
++            }
+         }
+         if (virtio_host_has_feature(vdev, VIRTIO_F_IOMMU_PLATFORM)) {
+             error_setg(errp, "VIRTIO_F_IOMMU_PLATFORM was supported by"
+diff --git a/hw/virtio/virtio.c b/hw/virtio/virtio.c
+index 3a3d012..a2edb4f 100644
+--- a/hw/virtio/virtio.c
++++ b/hw/virtio/virtio.c
+@@ -3304,6 +3304,11 @@ bool virtio_legacy_allowed(VirtIODevice *vdev)
+     }
+ }
+
++bool virtio_legacy_check_disabled(VirtIODevice *vdev)
++{
++    return vdev->disable_legacy_check;
++}
++
+ hwaddr virtio_queue_get_desc_addr(VirtIODevice *vdev, int n)
+ {
+     return vdev->vq[n].vring.desc;
+@@ -3713,6 +3718,8 @@ static Property virtio_properties[] = {
+     DEFINE_VIRTIO_COMMON_FEATURES(VirtIODevice, host_features),
+     DEFINE_PROP_BOOL("use-started", VirtIODevice, use_started, true),
+     DEFINE_PROP_BOOL("use-disabled-flag", VirtIODevice, use_disabled_flag, true),
++    DEFINE_PROP_BOOL("x-disable-legacy-check", VirtIODevice,
++                     disable_legacy_check, false),
+     DEFINE_PROP_END_OF_LIST(),
+ };
+
+diff --git a/include/hw/virtio/virtio.h b/include/hw/virtio/virtio.h
+index 28cf3b9..b7ece7a 100644
+--- a/include/hw/virtio/virtio.h
++++ b/include/hw/virtio/virtio.h
+@@ -101,6 +101,7 @@ struct VirtIODevice
+     bool use_started;
+     bool started;
+     bool start_on_kick; /* when virtio 1.0 feature has not been negotiated */
++    bool disable_legacy_check;
+     VMChangeStateEntry *vmstate;
+     char *bus_name;
+     uint8_t device_endian;
+@@ -394,5 +395,6 @@ static inline bool virtio_device_disabled(VirtIODevice *vdev)
+ }
+
+ bool virtio_legacy_allowed(VirtIODevice *vdev);
++bool virtio_legacy_check_disabled(VirtIODevice *vdev);
+
+ #endif
+--
+1.8.3.1

--- a/qemu/patches/5.1.x/0004-vhost-vsock-pci-force-virtio-version-1.patch
+++ b/qemu/patches/5.1.x/0004-vhost-vsock-pci-force-virtio-version-1.patch
@@ -1,0 +1,73 @@
+From 6209070503989cf4f28549f228989419d4f0b236 Mon Sep 17 00:00:00 2001
+From: Stefano Garzarella <sgarzare@redhat.com>
+Date: Mon, 21 Sep 2020 14:25:04 +0200
+Subject: [PATCH 2/4] vhost-vsock-pci: force virtio version 1
+
+Commit 9b3a35ec82 ("virtio: verify that legacy support is not
+accidentally on") added a safety check that requires to set
+'disable-legacy=on' on vhost-vsock-pci device:
+
+    $ ./qemu-system-x86_64 ... -device vhost-vsock-pci,guest-cid=5
+        qemu-system-x86_64: -device vhost-vsock-pci,guest-cid=5:
+        device is modern-only, use disable-legacy=on
+
+virtio-vsock was introduced after the release of VIRTIO 1.0
+specifications, so it should be 'modern-only'.
+In addition Cornelia verified that forcing a legacy mode on
+vhost-vsock-pci device using x86-64 host and s390x guest, so with
+different endianness, produces strange behaviours.
+
+This patch forces virtio version 1 and removes the 'transitional_name'
+property removing the need to specify 'disable-legacy=on' on
+vhost-vsock-pci device.
+
+To avoid migration issues, we force virtio version 1 only when
+legacy check is enabled in the new machine types (>= 5.1).
+
+As the transitional device name is not commonly used, we do not
+provide compatibility handling for it.
+
+Cc: qemu-stable@nongnu.org
+Reported-by: Qian Cai <caiqian@redhat.com>
+Reported-by: Qinghua Cheng <qcheng@redhat.com>
+Buglink: https://bugzilla.redhat.com/show_bug.cgi?id=1868449
+Suggested-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Cornelia Huck <cohuck@redhat.com>
+Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>
+Message-Id: <20200921122506.82515-3-sgarzare@redhat.com>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
+---
+ hw/virtio/vhost-vsock-pci.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/hw/virtio/vhost-vsock-pci.c b/hw/virtio/vhost-vsock-pci.c
+index e56067b..205da8d 100644
+--- a/hw/virtio/vhost-vsock-pci.c
++++ b/hw/virtio/vhost-vsock-pci.c
+@@ -44,6 +44,15 @@ static void vhost_vsock_pci_realize(VirtIOPCIProxy *vpci_dev, Error **errp)
+ {
+     VHostVSockPCI *dev = VHOST_VSOCK_PCI(vpci_dev);
+     DeviceState *vdev = DEVICE(&dev->vdev);
++    VirtIODevice *virtio_dev = VIRTIO_DEVICE(vdev);
++
++    /*
++     * To avoid migration issues, we force virtio version 1 only when
++     * legacy check is enabled in the new machine types (>= 5.1).
++     */
++    if (!virtio_legacy_check_disabled(virtio_dev)) {
++        virtio_pci_force_virtio_1(vpci_dev);
++    }
+
+     qdev_realize(vdev, BUS(&vpci_dev->bus), errp);
+ }
+@@ -73,7 +82,6 @@ static void vhost_vsock_pci_instance_init(Object *obj)
+ static const VirtioPCIDeviceTypeInfo vhost_vsock_pci_info = {
+     .base_name             = TYPE_VHOST_VSOCK_PCI,
+     .generic_name          = "vhost-vsock-pci",
+-    .transitional_name     = "vhost-vsock-pci-transitional",
+     .non_transitional_name = "vhost-vsock-pci-non-transitional",
+     .instance_size = sizeof(VHostVSockPCI),
+     .instance_init = vhost_vsock_pci_instance_init,
+--
+1.8.3.1

--- a/qemu/patches/5.1.x/0005-vhost-user-vsock-pci-force-virtio-version-1.patch
+++ b/qemu/patches/5.1.x/0005-vhost-user-vsock-pci-force-virtio-version-1.patch
@@ -1,0 +1,57 @@
+From 27eda699f59d430c33fc054a36a17251992e70dc Mon Sep 17 00:00:00 2001
+From: Stefano Garzarella <sgarzare@redhat.com>
+Date: Mon, 21 Sep 2020 14:25:05 +0200
+Subject: [PATCH 3/4] vhost-user-vsock-pci: force virtio version 1
+
+Commit 9b3a35ec82 ("virtio: verify that legacy support is not
+accidentally on") added a safety check that requires to set
+'disable-legacy=on' on vhost-user-vsock-pci device:
+
+    $ ./qemu-system-x86_64 ... \
+    -chardev socket,id=char0,reconnect=0,path=/tmp/vhost4.socket \
+    -device vhost-user-vsock-pci,chardev=char0
+        qemu-system-x86_64: -device vhost-user-vsock-pci,chardev=char0:
+        device is modern-only, use disable-legacy=on
+
+virtio-vsock was introduced after the release of VIRTIO 1.0
+specifications, so it should be 'modern-only'.
+
+This patch forces virtio version 1 and removes the 'transitional_name'
+property, as done for vhost-vsock-pci, removing the need to specify
+'disable-legacy=on' on vhost-user-vsock-pci device.
+
+Cc: qemu-stable@nongnu.org
+Suggested-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Cornelia Huck <cohuck@redhat.com>
+Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>
+Message-Id: <20200921122506.82515-4-sgarzare@redhat.com>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
+---
+ hw/virtio/vhost-user-vsock-pci.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/hw/virtio/vhost-user-vsock-pci.c b/hw/virtio/vhost-user-vsock-pci.c
+index 763f899..72a9619 100644
+--- a/hw/virtio/vhost-user-vsock-pci.c
++++ b/hw/virtio/vhost-user-vsock-pci.c
+@@ -41,6 +41,9 @@ static void vhost_user_vsock_pci_realize(VirtIOPCIProxy *vpci_dev, Error **errp)
+     VHostUserVSockPCI *dev = VHOST_USER_VSOCK_PCI(vpci_dev);
+     DeviceState *vdev = DEVICE(&dev->vdev);
+
++    /* unlike vhost-vsock, we do not need to care about pre-5.1 compat */
++    virtio_pci_force_virtio_1(vpci_dev);
++
+     qdev_realize(vdev, BUS(&vpci_dev->bus), errp);
+ }
+
+@@ -69,7 +72,6 @@ static void vhost_user_vsock_pci_instance_init(Object *obj)
+ static const VirtioPCIDeviceTypeInfo vhost_user_vsock_pci_info = {
+     .base_name             = TYPE_VHOST_USER_VSOCK_PCI,
+     .generic_name          = "vhost-user-vsock-pci",
+-    .transitional_name     = "vhost-user-vsock-pci-transitional",
+     .non_transitional_name = "vhost-user-vsock-pci-non-transitional",
+     .instance_size = sizeof(VHostUserVSockPCI),
+     .instance_init = vhost_user_vsock_pci_instance_init,
+--
+1.8.3.1

--- a/qemu/patches/5.1.x/0006-vhost-vsock-ccw-force-virtio-version-1.patch
+++ b/qemu/patches/5.1.x/0006-vhost-vsock-ccw-force-virtio-version-1.patch
@@ -1,0 +1,52 @@
+From a6704a34cf02add13964149e0de6453ae62bd9db Mon Sep 17 00:00:00 2001
+From: Stefano Garzarella <sgarzare@redhat.com>
+Date: Mon, 21 Sep 2020 14:25:06 +0200
+Subject: [PATCH 4/4] vhost-vsock-ccw: force virtio version 1
+
+virtio-vsock was introduced after the release of VIRTIO 1.0
+specifications, so it should be 'modern-only'.
+
+This patch forces virtio version 1 as done for vhost-vsock-pci.
+
+To avoid migration issues, we force virtio version 1 only when
+legacy check is enabled in the new machine types (>= 5.1).
+
+Cc: qemu-stable@nongnu.org
+Suggested-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Cornelia Huck <cohuck@redhat.com>
+Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>
+Message-Id: <20200921122506.82515-5-sgarzare@redhat.com>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
+---
+ hw/s390x/vhost-vsock-ccw.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/hw/s390x/vhost-vsock-ccw.c b/hw/s390x/vhost-vsock-ccw.c
+index 0822ecc..246416a 100644
+--- a/hw/s390x/vhost-vsock-ccw.c
++++ b/hw/s390x/vhost-vsock-ccw.c
+@@ -40,9 +40,21 @@ static void vhost_vsock_ccw_class_init(ObjectClass *klass, void *data)
+ static void vhost_vsock_ccw_instance_init(Object *obj)
+ {
+     VHostVSockCCWState *dev = VHOST_VSOCK_CCW(obj);
++    VirtioCcwDevice *ccw_dev = VIRTIO_CCW_DEVICE(obj);
++    VirtIODevice *virtio_dev;
+
+     virtio_instance_init_common(obj, &dev->vdev, sizeof(dev->vdev),
+                                 TYPE_VHOST_VSOCK);
++
++    virtio_dev = VIRTIO_DEVICE(&dev->vdev);
++
++    /*
++     * To avoid migration issues, we force virtio version 1 only when
++     * legacy check is enabled in the new machine types (>= 5.1).
++     */
++    if (!virtio_legacy_check_disabled(virtio_dev)) {
++        ccw_dev->force_revision_1 = true;
++    }
+ }
+
+ static const TypeInfo vhost_vsock_ccw_info = {
+--
+1.8.3.1

--- a/static-build/qemu.blacklist
+++ b/static-build/qemu.blacklist
@@ -3,8 +3,6 @@
 # required in kata and may have CVEs.
 #
 qemu_black_list=(
-*/bin/qemu-pr-helper
-*/bin/virtfs-proxy-helper
 */libexec/
 */share/*/applications/
 */share/*/*.dtb


### PR DESCRIPTION
Certain config options have been deprecated with 5.1.
Remove these.

Depends-on: github.com/kata-containers/runtime#2993

Fixes #1150

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>