### PR TITLE
[forward port]: kata-deploy: Fix typo #591

### DIFF
--- a/kata-deploy/README.md
+++ b/kata-deploy/README.md
@@ -125,7 +125,7 @@ spec:
       runtimeClassName: kata-qemu
 ```
 
-The following YAML snippet shows how to specify a runtime class with Kata for Firecracker:
+The following YAML snippet shows how to specify a runtime class with use Kata for Firecracker:
 
 ```yaml
 spec:


### PR DESCRIPTION
Parent PR:
https://github.com/kata-containers/packaging/pull/992


The issue this fixes is in the main kata-containers repo, not packaging. We're not sure how exactly to format the PR properly.