### PR TITLE
qemu: Install virtiofs with vanilla qemu.

### DIFF
--- a/.ci/packaging/setup.sh
+++ b/.ci/packaging/setup.sh
@@ -15,5 +15,9 @@ export kata_repo="github.com/kata-containers/packaging"
 export pr_number=${GITHUB_PR:-}
 export pr_branch="PR_${pr_number}"
 
-go get github.com/kata-containers/tests
-${GOPATH}/src/github.com/kata-containers/tests/.ci/resolve-kata-dependencies.sh
+TEST_REPO_DIR="${GOPATH}/src/github.com/kata-containers/tests"
+mkdir -p $(dirname "TEST_REPO_DIR")
+git clone https://github.com/kata-containers/packaging.git "${TEST_REPO_DIR}"
+
+git checkout "${branch}"
+"${TEST_REPO_DIR}"/.ci/resolve-kata-dependencies.sh

--- a/kernel/patches/5.4.x/0002-ACPI-Always-build-evged-in.patch
+++ b/kernel/patches/5.4.x/0002-ACPI-Always-build-evged-in.patch
@@ -1,0 +1,39 @@
+From ac36d37e943635fc072e9d4f47e40a48fbcdb3f0 Mon Sep 17 00:00:00 2001
+From: Arjan van de Ven <arjan@linux.intel.com>
+Date: Wed, 9 Oct 2019 15:04:33 +0200
+Subject: ACPI: Always build evged in
+
+Although the Generic Event Device is a Hardware-reduced
+platfom device in principle, it should not be restricted to
+ACPI_REDUCED_HARDWARE_ONLY.
+
+Kernels supporting both fixed and hardware-reduced ACPI platforms
+should be able to probe the GED when dynamically detecting that a
+platform is hardware-reduced. For that, the driver must be
+unconditionally built in.
+
+Signed-off-by: Arjan van de Ven <arjan@linux.intel.com>
+Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>
+Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+---
+ drivers/acpi/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+(limited to 'drivers/acpi/Makefile')
+
+diff --git a/drivers/acpi/Makefile b/drivers/acpi/Makefile
+index 5d361e4e3405..ef1ac4d127da 100644
+--- a/drivers/acpi/Makefile
++++ b/drivers/acpi/Makefile
+@@ -48,7 +48,7 @@ acpi-y				+= acpi_pnp.o
+ acpi-$(CONFIG_ARM_AMBA)	+= acpi_amba.o
+ acpi-y				+= power.o
+ acpi-y				+= event.o
+-acpi-$(CONFIG_ACPI_REDUCED_HARDWARE_ONLY) += evged.o
++acpi-y				+= evged.o
+ acpi-y				+= sysfs.o
+ acpi-y				+= property.o
+ acpi-$(CONFIG_X86)		+= acpi_cmos_rtc.o
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/scripts/configure-hypervisor.sh
+++ b/scripts/configure-hypervisor.sh
@@ -402,9 +402,11 @@ generate_qemu_options() {
 	# (-fsdev "...,security_model=passthrough,..."), qemu uses a helper
 	# application called virtfs-proxy-helper(1) to make certain 9p
 	# operations safer.
+	# seccomp required by virtiofsd
 	qemu_options+=(functionality:--enable-virtfs)
 	qemu_options+=(functionality:--enable-attr)
 	qemu_options+=(functionality:--enable-cap-ng)
+	qemu_options+=(functionality:--enable-seccomp)
 
 	if [[ "${qemu_version_major}" -ge 4 || ( "${qemu_version_major}" -eq 3  &&  "${qemu_version_minor}" -ge 1 ) ]]; then
 		# AVX2 is enabled by default by x86_64, make sure it's enabled only

--- a/static-build/qemu-virtiofs/Dockerfile
+++ b/static-build/qemu-virtiofs/Dockerfile
@@ -67,5 +67,5 @@ RUN make -j$(nproc)
 RUN make -j$(nproc) virtiofsd
 RUN make install DESTDIR=/tmp/qemu-virtiofs-static
 RUN mv /tmp/qemu-virtiofs-static/"${PREFIX}"/bin/qemu-system-x86_64 /tmp/qemu-virtiofs-static/"${PREFIX}"/bin/qemu-virtiofs-system-x86_64
-RUN chmod +x virtiofsd && mv virtiofsd /tmp/qemu-virtiofs-static/opt/kata/bin/
+RUN chmod +x virtiofsd && mv virtiofsd "/tmp/qemu-virtiofs-static/${PREFIX}/bin/virtiofsd-experimental"
 RUN cd /tmp/qemu-virtiofs-static && tar -czvf "${QEMU_TARBALL}"  *

--- a/static-build/qemu/Dockerfile
+++ b/static-build/qemu/Dockerfile
@@ -32,10 +32,11 @@ RUN apt-get --no-install-recommends install -y \
 	    libmount-dev \
 	    libpixman-1-dev \
 	    libpmem-dev \
+	    libseccomp-dev \
+	    libseccomp2 \
 	    libselinux1-dev \
 	    libtool \
 	    make \
-	    pkg-config \
 	    pkg-config \
 	    python \
 	    python-dev \
@@ -59,4 +60,8 @@ RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-qemu | xargs ./conf
 
 RUN make -j$(nproc)
 RUN make install DESTDIR=/tmp/qemu-static
+
+RUN make -j$(nproc) virtiofsd
+RUN chmod +x virtiofsd && mv virtiofsd "/tmp/qemu-static/${PREFIX}/bin/"
+
 RUN cd /tmp/qemu-static && tar -czvf "${QEMU_TARBALL}" *


### PR DESCRIPTION
Default kata should provide virtiofs from vanilla qemu.
If users want experimental virtiofs can change to experimental binaries
manually.

Depends-on: github.com/kata-containers/runtime#3122
Depends-on: github.com/kata-containers/tests#3173

Fixes: github.com/kata-containers/runtime#3083

Signed-off-by: Carlos Venegas <jos.c.venegas.munoz@intel.com>
