### PR TITLE
static-build: Pull the release binary of cloud-hypervisor first

### DIFF
--- a/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/static-build/cloud-hypervisor/build-static-clh.sh
@@ -27,15 +27,30 @@ fi
 [ -n "$cloud_hypervisor_version" ] || cloud_hypervisor_version=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.version" "${kata_version}")
 [ -n "$cloud_hypervisor_version" ] || die "failed to get cloud_hypervisor version"
 
-info "Build ${cloud_hypervisor_repo} version: ${cloud_hypervisor_version}"
+pull_clh_released_binary() {
+    info "Download cloud-hypervisor version: ${cloud_hypervisor_version}"
+    cloud_hypervisor_binary="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${cloud_hypervisor_version}/cloud-hypervisor-static"
 
-repo_dir=$(basename "${cloud_hypervisor_repo}")
-repo_dir="${repo_dir//.git}"
+    curl --fail -L ${cloud_hypervisor_binary} -o cloud-hypervisor-static || return 1
+    mkdir -p cloud-hypervisor
+    mv -f cloud-hypervisor-static cloud-hypervisor/cloud-hypervisor
+}
 
-[ -d "${repo_dir}" ] || git clone "${cloud_hypervisor_repo}"
-cd "${repo_dir}"
-git fetch || true
-git checkout "${cloud_hypervisor_version}"
-./scripts/dev_cli.sh build --release --libc musl
-rm -f cloud-hypervisor
-cp build/cargo_target/$(uname -m)-unknown-linux-musl/release/cloud-hypervisor .
+build_clh_from_source() {
+    info "Build ${cloud_hypervisor_repo} version: ${cloud_hypervisor_version}"
+    repo_dir=$(basename "${cloud_hypervisor_repo}")
+    repo_dir="${repo_dir//.git}"
+    [ -d "${repo_dir}" ] || git clone "${cloud_hypervisor_repo}"
+    pushd "${repo_dir}"
+    git fetch || true
+    git checkout "${cloud_hypervisor_version}"
+    ./scripts/dev_cli.sh build --release --libc musl
+    rm -f cloud-hypervisor
+    cp build/cargo_target/$(uname -m)-unknown-linux-musl/release/cloud-hypervisor .
+    popd
+}
+
+if ! pull_clh_released_binary; then
+    info "failed to pull cloud-hypervisor released binary, trying to build from source"
+    build_clh_from_source
+fi


### PR DESCRIPTION
Try to pull the cloud-hypervisor from its release page first. If it
failed, we build the clh binary from scratch.

Fixes: #1191

Signed-off-by: Bo Chen <chen.bo@intel.com>
Signed-off-by: Peng Tao <bergwolf@hyper.sh>